### PR TITLE
Add CI testing for PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,23 @@
+---
+
+name: Run Pull Request CI Verification
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    container:
+      image: registry.suse.com/bci/golang:1.21-openssl
+
+    steps:
+      - name: Checkout PR sources
+        uses: actions/checkout@v4
+        with:
+          path: telemetry
+
+      - name: Run tests in verbose mode
+        run: cd telemetry && make test-verbose

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := build
 
-.PHONY: fmt vet build test
+.PHONY: fmt vet build clean test test-verbose
 
 fmt:
 	go fmt ./...

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # telemetry
-Proof of Concept Telemetry scaffolding
+SUSE Telemetry Client Library and associated client CLI tools
 
 # What's available
 
@@ -34,6 +34,16 @@ The pkg/types module defined useful common types
 ## pkg/lib
 The pkg/lib module provides functionality for managing the local staging
 of data items, bundles and reports.
+
+# Testing
+
+The tests can be run from within the telemetry repo as follows:
+
+```
+% cd telemetry
+% make test
+```
+
 
 # See Also
 See the companion telemetry-server repo for a basic implementation of


### PR DESCRIPTION
Add a GitHub actions workflow to run our tests when a PR is proposed or updated.

Update Makefile's .PHONY list to include all of our targets.

Update README.md with instructions on how to run tests and update some stale text.

Closes: #13