### PR TITLE
Add SLE-SERVER-SCCHwInfo test data

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,30 @@ of data items, bundles and reports.
 
 # Testing
 
-The tests can be run from within the telemetry repo as follows:
+## Verification Testing
+The verification tests can be run from within the telemetry repo as follows:
 
 ```
 % cd telemetry
 % make test
 ```
+
+## Local Developer Testing
+First ensure that the SUSE/telemetry-server is running with the local
+server config file. Then run the cmd/generator tool from the telemetry
+tool as follows to generate telemetry data, including a DEVTEST tag,
+and submit telemetry to the server, self-registering as a client with
+the server if needed:
+
+```
+% cd telemetry/cmd/generator
+% go run . --config ../../testdata/config/localClient.yaml \
+      --telemetry=SLE-SERVER-SCCHwInfo --tag DEVTEST \
+      ../../testdata/telemetry/SLE-SERVER-SCCHwInfo/sle12sp5-test.json
+```
+
+If you just want to generate but not submit, then you can include the
+--nosubmit option.
 
 
 # See Also

--- a/testdata/telemetry/SLE-SERVER-SCCHwInfo/sle12sp5-test.json
+++ b/testdata/telemetry/SLE-SERVER-SCCHwInfo/sle12sp5-test.json
@@ -1,0 +1,14 @@
+{
+  "hostname": "sle12sp5-test",
+  "distro_target": "sle-12-x86_64",
+  "hwinfo": {
+    "hostname": "sle12sp5-test",
+    "cpus": 2,
+    "sockets": 1,
+    "hypervisor": "KVM",
+    "arch": "x86_64",
+    "uuid": "192653D9-245A-438F-A3F6-4EED1A9C11F3",
+    "cloud_provider": "",
+    "mem_total": 4096
+  }
+}


### PR DESCRIPTION
Add test data for a SLE-SERVER-SCCHwInfo telemetry type.

Update the README.md with instructions on how to use the cmd/generator to run developer tests against a local telemetry server instance.

Closes: #16