### PR TITLE
Client Data Store Enhancements and Bug fixes

### DIFF
--- a/cmd/clientds/main.go
+++ b/cmd/clientds/main.go
@@ -40,7 +40,7 @@ func main() {
 	processor := tc.Processor()
 
 	if opts.items {
-		itemRows, err := processor.GetDataItemRows()
+		itemRows, err := processor.GetItemRows()
 		if err != nil {
 			log.Fatal(err.Error())
 		}

--- a/pkg/lib/bundles.go
+++ b/pkg/lib/bundles.go
@@ -56,7 +56,10 @@ const bundlesColumns = `(
 	bundleAnnotations TEXT,
 	bundleChecksum VARCHAR(256),
 	reportId  INTEGER NULL,
-	FOREIGN KEY (reportId) REFERENCES reports(id)
+	CONSTRAINT bundles_reportId
+	  FOREIGN KEY (reportId)
+		REFERENCES reports(id)
+	  ON DELETE CASCADE
 )`
 
 type TelemetryBundleRow struct {

--- a/pkg/lib/items.go
+++ b/pkg/lib/items.go
@@ -65,7 +65,10 @@ const itemsColumns = `(
 	itemData BLOB NOT NULL,
 	itemChecksum VARCHAR(256),
 	bundleId INTEGER NULL,
-	FOREIGN KEY (bundleId) REFERENCES bundles(id)
+	CONSTRAINT items_bundleId
+	  FOREIGN KEY (bundleId)
+		REFERENCES bundles(id)
+	  ON DELETE CASCADE
 )`
 
 type TelemetryDataItemRow struct {

--- a/pkg/lib/reports.go
+++ b/pkg/lib/reports.go
@@ -50,8 +50,7 @@ const reportsColumns = `(
 	reportTimestamp VARCHAR(32) NOT NULL,
 	reportClientId INTEGER NOT NULL,
 	reportAnnotations TEXT,
-	reportChecksum VARCHAR(256),
-	FOREIGN KEY (reportId) REFERENCES bundles(id)
+	reportChecksum VARCHAR(256)
 )`
 
 type TelemetryReportRow struct {


### PR DESCRIPTION
Leverage foreign key cascaded delete constraints to ensure that deletion of reports triggers a cascaded delete of associated bundles, triggering cascaded deletes of associated bundles.

To support this we need to ensure that SQLite3 foreign_key processing is enabled when we open the SQLite3 based client data store. Similarly we want to enable Write Ahead Log (WAL) based journalling mode for our data store. These options will be automatically included in the SQLite3 data source specification if not already provided.

Cleanup the TelemetryProcessor and associated TelemetryCommon interface definitions, leveraging variadic functions to eliminate multiple similar methods. Similarly for the DatabaseStorer interface. Update associated implementations to match revised interface definitions and remove any newly redundant methods.

Implement helper functions that can be used to generate the SQL queries needed to populate the row structures of a table, or count the number of matching rows.

Update test cases to ensure that deleting a report triggers appropriate cascaded deletes that remove associated bundles and items.

Relates: #19
Closes: #20 #18