### PR TITLE
Switch to using a JWT as the auth token

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -2,9 +2,7 @@ package client
 
 import (
 	"bytes"
-	"crypto/sha256"
 	"encoding/base64"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -30,21 +28,6 @@ type TelemetryAuth struct {
 	ClientId  int64                    `json:"clientId"`
 	Token     types.TelemetryAuthToken `json:"token"`
 	IssueDate types.TelemetryTimeStamp `json:"issueDate"`
-
-	tokenSha256 types.TelemetryAuthToken
-}
-
-func (t *TelemetryAuth) TokenSha256(token types.TelemetryAuthToken) types.TelemetryAuthToken {
-	if t.tokenSha256 != "" {
-		return t.tokenSha256
-	}
-
-	hash := sha256.New()
-	hash.Write([]byte(token))
-	hashedToken := types.TelemetryAuthToken(hex.EncodeToString(hash.Sum(nil)))
-	t.tokenSha256 = hashedToken
-
-	return t.tokenSha256
 }
 
 type TelemetryClient struct {
@@ -128,7 +111,7 @@ func (tc *TelemetryClient) loadTelemetryAuth() (err error) {
 	slog.Info("Checking auth file existence", slog.String("authPath", authPath))
 	_, err = os.Stat(authPath)
 	if os.IsNotExist(err) {
-		slog.Error(
+		slog.Warn(
 			"unable to find auth file",
 			slog.String("authPath", authPath),
 			slog.String("err", err.Error()),
@@ -179,8 +162,6 @@ func (tc *TelemetryClient) loadTelemetryAuth() (err error) {
 		return
 	}
 
-	_ = tc.auth.TokenSha256(tc.auth.Token)
-
 	return
 }
 
@@ -224,7 +205,7 @@ func (tc *TelemetryClient) submitReport(report *telemetrylib.TelemetryReport) (e
 	}
 
 	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("X-AuthToken", string(tc.auth.TokenSha256(tc.auth.Token)))
+	req.Header.Add("Authorization", "Bearer "+tc.auth.Token.String())
 
 	httpClient := http.DefaultClient
 	resp, err := httpClient.Do(req)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -53,6 +53,10 @@ func (t TelemetryAuthToken) Valid() bool {
 	return t != ""
 }
 
+func (t *TelemetryAuthToken) String() string {
+	return string(*t)
+}
+
 // TelemetryType is a string of the format "<family>-<stream>-<subtype>"
 type TelemetryType string
 


### PR DESCRIPTION
As part of the first phase of finalising the authentication method we need to update the client side to send an Authorization header using the Bearer schema that includes the auth token obtained from the telemetry server via a previous /register request.

Remove redundant TokenSha256code.

Relates: #34