### PR TITLE
Implement telemetry client interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # telemetry
 SUSE Telemetry Client Library and associated client CLI tools
 
+See [examples](examples/) directory for examples of how to use the
+Telemetry Client library.
+
 # What's available
 
 ## cmd/generator

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,14 @@
+# Telemetry Examples
+This directory contains examples of:
+* telemetry client configuration files
+* telemetry data item payloads
+* application integration with telemetry client
+
+The [app](app/) directory contains a minimal example of using the
+telemetry client from a Go application.
+
+The [config](config/) directory contains example configuration files
+for use with these examples.
+
+The [telemetry](telemetry/) directory contains example telemetry data
+item JSON blob payloads named for their associated telemetry type.

--- a/examples/app/go.mod
+++ b/examples/app/go.mod
@@ -1,0 +1,14 @@
+module github.com/SUSE/telemetry/examples/app
+
+go 1.21.9
+
+replace github.com/SUSE/telemetry => ../../
+
+require github.com/SUSE/telemetry v0.0.0-00010101000000-000000000000
+
+require (
+	github.com/google/uuid v1.6.0 // indirect
+	github.com/mattn/go-sqlite3 v1.14.22 // indirect
+	github.com/xyproto/randomstring v1.0.5 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/examples/app/go.sum
+++ b/examples/app/go.sum
@@ -1,0 +1,16 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
+github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
+github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/examples/app/main.go
+++ b/examples/app/main.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	"github.com/SUSE/telemetry"
+)
+
+func status_check_example() {
+	status := telemetry.Status()
+	slog.Info("Telemetry Client", slog.String("status", status.String()))
+}
+
+type SomeTelemetryType struct {
+	Version     int      `json:"version"`
+	Application string   `json:"application"`
+	Fields      []string `josn:"fields"`
+}
+
+func (stt *SomeTelemetryType) String() string {
+	return fmt.Sprintf("%+v", *stt)
+}
+
+func telemetry_content() []byte {
+	appTelemetry := SomeTelemetryType{
+		Version:     1,
+		Application: "specific",
+		Fields: []string{
+			"Of",
+			"Data",
+		},
+	}
+
+	content, err := json.Marshal(appTelemetry)
+	if err != nil {
+		slog.Error(
+			"Failed to json.Marshal() content",
+			slog.Any("telemetry", appTelemetry),
+			slog.String("error", err.Error()),
+		)
+		panic(fmt.Errorf("json.Marshal() failed: %s", err.Error()))
+	}
+
+	return content
+}
+
+func generate_telemetry_example() {
+	telemetryType := telemetry.TelemetryType("SOME-TELEMETRY-TYPE")
+	class := telemetry.MANDATORY_TELEMETRY
+	content := telemetry_content()
+	tags := telemetry.Tags{}
+	flags := telemetry.GENERATE | telemetry.SUBMIT
+
+	// verify the telemetry type
+	if valid, err := telemetryType.Valid(); !valid {
+		slog.Error(
+			"Invalid telemetry type",
+			slog.Any("type", telemetryType),
+			slog.String("error", err.Error()),
+		)
+		return
+	}
+
+	err := telemetry.Generate(
+		telemetryType,
+		class,
+		content,
+		tags,
+		flags)
+	if err != nil {
+		slog.Error(
+			"Generate() failed",
+			slog.String("type", telemetryType.String()),
+			slog.String("class", class.String()),
+			slog.Any("content", content),
+			slog.String("tags", tags.String()),
+			slog.String("flags", flags.String()),
+			slog.String("error", err.Error()),
+		)
+	}
+}
+
+func main() {
+	status_check_example()
+	generate_telemetry_example()
+}

--- a/examples/config/telemetry.yaml
+++ b/examples/config/telemetry.yaml
@@ -5,15 +5,12 @@ tags: []
 datastores:
   driver: sqlite3
   params: /tmp/telemetry/client/telemetry.db
-extras:
-  some: thing
-  else:
-    - one
-    - two
-    - three
-  or:
-    maybe: 2024
 logging:
   level: info
   location: stderr
   style: text
+class_options:
+  opt_out: true
+  opt_in: false
+  allow: []
+  deny: []

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -26,6 +26,13 @@ func (t *TestConfigTestSuite) TestConfigFileNotFound() {
 	assert.Equal(t.T(), DefaultCfg.Tags, config.Tags, "Tags value is not the expected")
 	assert.Equal(t.T(), DefaultCfg.DataStores.Driver, config.DataStores.Driver, "DataStores.Driver is not the expected")
 	assert.Equal(t.T(), DefaultCfg.DataStores.Params, config.DataStores.Params, "DataStores.Params is not the expected")
+	assert.Equal(t.T(), DefaultCfg.Logging.Level, config.Logging.Level, "Logging.Level is not the expected")
+	assert.Equal(t.T(), DefaultCfg.Logging.Location, config.Logging.Location, "Logging.Location is not the expected")
+	assert.Equal(t.T(), DefaultCfg.Logging.Style, config.Logging.Style, "Logging.Style is not the expected")
+	assert.Equal(t.T(), DefaultCfg.ClassOptions.OptOut, config.ClassOptions.OptOut, "ClassOptions.OptOut is not the expected")
+	assert.Equal(t.T(), DefaultCfg.ClassOptions.OptIn, config.ClassOptions.OptIn, "ClassOptions.OptIn is not the expected")
+	assert.Equal(t.T(), DefaultCfg.ClassOptions.Allow, config.ClassOptions.Allow, "ClassOptions.Allow is not the expected")
+	assert.Equal(t.T(), DefaultCfg.ClassOptions.Deny, config.ClassOptions.Deny, "ClassOptions.Deny is not the expected")
 }
 
 func (t *TestConfigTestSuite) TestConfigFileFound() {
@@ -38,14 +45,23 @@ func (t *TestConfigTestSuite) TestConfigFileFound() {
 	params := "/tmp/telemetry/testcfg/telemetry.db"
 
 	content := `
-    telemetry_base_url: %s
-    enabled: true
-    customer_id: 01234
-    tags: []
-    datastores:
-      driver: %s
-      params: %s
-    `
+telemetry_base_url: %s
+enabled: true
+customer_id: 01234
+tags: []
+datastores:
+  driver: %s
+  params: %s
+logging:
+  level: info
+  location: stderr
+  style: text
+class_options:
+  opt_out: true
+  opt_in: false
+  allow: []
+  deny: []
+`
 
 	formattedContents := fmt.Sprintf(content, url, driver, params)
 	_, err = tmpfile.Write([]byte(formattedContents))
@@ -70,14 +86,23 @@ func (t *TestConfigTestSuite) TestConfigFileFoundButUnparsable() {
 	params := "/tmp/telemetry/testcfg/telemetry.db"
 
 	content := `
-    telemetry_base_url: %s
-    enabled true
-    customer_id: 01234
-    tags: []
-    datastores:
-      driver: %s
-      params: %s
-    `
+telemetry_base_url: %s
+enabled true
+customer_id: 01234
+tags: []
+datastores:
+  driver: %s
+  params: %s
+logging:
+  level: info
+  location: stderr
+  style: text
+class_options:
+  opt_out: true
+  opt_in: false
+  allow: []
+  deny: []
+`
 
 	formattedContents := fmt.Sprintf(content, url, driver, params)
 	_, err = tmpfile.Write([]byte(formattedContents))

--- a/pkg/lib/testdata/config/processor/defaultEnvProcessor.yaml
+++ b/pkg/lib/testdata/config/processor/defaultEnvProcessor.yaml
@@ -1,7 +1,15 @@
-
 enabled: true
 customer_id: 1234567890
 tags: []
 datastores:
   driver: sqlite3
   params: /tmp/telemetry/processor/telemetry.db
+logging:
+  level: info
+  location: stderr
+  style: text
+class_options:
+  opt_out: true
+  opt_in: false
+  allow: []
+  deny: []

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -103,3 +103,23 @@ func Now() TelemetryTimeStamp {
 	t := TelemetryTimeStamp{time.Now()}
 	return t
 }
+
+type TelemetryClass int64
+
+const (
+	MANDATORY_TELEMETRY TelemetryClass = iota
+	OPT_OUT_TELEMETRY
+	OPT_IN_TELEMETRY
+)
+
+func (tc *TelemetryClass) String() string {
+	switch *tc {
+	case MANDATORY_TELEMETRY:
+		return "MANDATORY"
+	case OPT_OUT_TELEMETRY:
+		return "OPT-OUT"
+	case OPT_IN_TELEMETRY:
+		return "OPT-IN"
+	}
+	return "UNKNOWN_TELEMETRY_CLASS"
+}

--- a/telemetry.go
+++ b/telemetry.go
@@ -1,0 +1,223 @@
+package telemetry
+
+import (
+	"log/slog"
+
+	"github.com/SUSE/telemetry/pkg/client"
+	"github.com/SUSE/telemetry/pkg/config"
+	"github.com/SUSE/telemetry/pkg/types"
+)
+
+type TelemetryType = types.TelemetryType
+
+type Tags = types.Tags
+
+type TelemetryClass = types.TelemetryClass
+
+const (
+	MANDATORY_TELEMETRY = types.MANDATORY_TELEMETRY
+	OPT_OUT_TELEMETRY   = types.OPT_OUT_TELEMETRY
+	OPT_IN_TELEMETRY    = types.OPT_IN_TELEMETRY
+)
+
+type GenerateFlags uint64
+
+const (
+	GENERATE GenerateFlags = iota
+	SUBMIT   GenerateFlags = 1 << (iota - 1)
+)
+
+func (gf *GenerateFlags) String() string {
+	flags := "GENERATE"
+	switch {
+	case gf.FlagSet(SUBMIT):
+		flags += "|SUBMIT"
+		fallthrough
+	default:
+		// nothing to do
+	}
+	return flags
+}
+
+func (gf GenerateFlags) FlagSet(flag GenerateFlags) bool {
+	return (gf & flag) == flag
+}
+
+func (gf GenerateFlags) SubmitRequested() bool {
+	return gf.FlagSet(SUBMIT)
+}
+
+func Generate(telemetry types.TelemetryType, class TelemetryClass, content []byte, tags types.Tags, flags GenerateFlags) (err error) {
+	// check that the telemetry type is valid
+	if valid, err := telemetry.Valid(); !valid {
+		slog.Error(
+			"Invalid telemetry type",
+			slog.String("type", string(telemetry)),
+		)
+		return err
+	}
+
+	// attempt to load the default config file
+	cfg, err := config.NewConfig(client.CONFIG_PATH)
+	if err != nil {
+		slog.Error(
+			"Failed to load telemetry client config",
+			slog.String("path", client.CONFIG_PATH),
+			slog.String("error", err.Error()),
+		)
+		return
+	}
+
+	// check if the telemetry client is enabled in config
+	if !cfg.Enabled {
+		slog.Warn("The telemetry client is disabled in the configuration; no telemetry generated")
+		return
+	}
+
+	// check that the telemetry class is enabled for generation
+	if !cfg.TelemetryClassEnabled(class) {
+		slog.Warn(
+			"Telemetry class generation is disabled",
+			slog.String("class", class.String()),
+		)
+		return
+	}
+
+	// check that the telemetry type is enabled for generation
+	if !cfg.TelemetryTypeEnabled(telemetry) {
+		slog.Warn(
+			"Telemetry class generation is disabled",
+			slog.String("class", class.String()),
+		)
+		return
+	}
+
+	// instantiate a telemetry client
+	tc, err := client.NewTelemetryClient(cfg)
+	if err != nil {
+		slog.Warn(
+			"Failed to instantiate a TelemetryClient",
+			slog.String("error", err.Error()),
+		)
+		return
+	}
+
+	// ensure the client is registered
+	err = tc.Register()
+	if err != nil {
+		slog.Warn(
+			"Failed to register TelemetryClient with upstream server",
+			slog.String("error", err.Error()),
+		)
+		return
+	}
+
+	// generate the telemetry, storing it in the local data store
+	err = tc.Generate(telemetry, content, tags)
+	if err != nil {
+		slog.Warn(
+			"Failed to generate telemetry",
+			slog.String("error", err.Error()),
+		)
+		return
+	}
+
+	// check if immediate submission requested
+	if flags.SubmitRequested() {
+		// TODO: implement immediate submission
+		slog.Info("Immediate Telemetry Submission requested")
+	}
+
+	return
+}
+
+type ClientStatus int64
+
+const (
+	CLIENT_UNINITIALIZED ClientStatus = iota
+	CLIENT_CONFIG_ACCESSIBLE
+	CLIENT_DISABLED
+	CLIENT_MISCONFIGURED
+	CLIENT_DATASTORE_ACCESSIBLE
+	CLIENT_INSTANCE_ID_ACCESSIBLE
+	CLIENT_REGISTERED
+)
+
+func (cs *ClientStatus) String() string {
+	switch *cs {
+	case CLIENT_UNINITIALIZED:
+		return "UNITITIALIZED"
+	case CLIENT_CONFIG_ACCESSIBLE:
+		return "CONFIG_ACCESSIBLE"
+	case CLIENT_DISABLED:
+		return "DISABLED"
+	case CLIENT_MISCONFIGURED:
+		return "MISCONFIGURED"
+	case CLIENT_DATASTORE_ACCESSIBLE:
+		return "DATASTORE_ACCESSIBLE"
+	case CLIENT_INSTANCE_ID_ACCESSIBLE:
+		return "INSTANCE_ID_ACCESSIBLE"
+	case CLIENT_REGISTERED:
+		return "REGISTERED"
+	}
+	return "UNKNOWN_TELEMETRY_CLIENT_STATUS"
+}
+
+func Status() (status ClientStatus) {
+	// default to being uninitialised
+	status = CLIENT_UNINITIALIZED
+
+	// attempt to load the default config
+	cfg, err := config.NewConfig(client.CONFIG_PATH)
+	if err != nil {
+		slog.Warn(
+			"Failed to load telemetry client config",
+			slog.String("path", client.CONFIG_PATH),
+			slog.String("error", err.Error()),
+		)
+		return
+	}
+
+	// update status to indicate that telemetry client configuration is accessible
+	status = CLIENT_CONFIG_ACCESSIBLE
+
+	// check if the telemetry client is enabled in config
+	if !cfg.Enabled {
+		slog.Info("The telemetry client is disabled in the configuration")
+		return CLIENT_DISABLED
+	}
+
+	// instantiate a telemetry client using provided config
+	tc, err := client.NewTelemetryClient(cfg)
+	if err != nil {
+		slog.Warn(
+			"Failed to setup telemetry client using provided config",
+			slog.String("path", client.CONFIG_PATH),
+			slog.String("error", err.Error()),
+		)
+		return CLIENT_MISCONFIGURED
+	}
+
+	// update status to indicate that telemetry client datastore is accessible
+	status = CLIENT_DATASTORE_ACCESSIBLE
+
+	// check that an instance id is available
+	if !tc.InstanceIdAccessible() {
+		slog.Warn("Telemetry client instance id has not been setup", slog.String("path", tc.InstIdPath()))
+		return
+	}
+
+	// update status to indicate client has instance id
+	status = CLIENT_INSTANCE_ID_ACCESSIBLE
+
+	// check that we have obtained a telemetry auth token
+	if !tc.AuthAccessible() {
+		slog.Warn("Telemetry client has not been registered", slog.String("path", tc.AuthPath()))
+		return
+	}
+
+	// update status to indicate telemetry client is registered
+	status = CLIENT_REGISTERED
+
+	return
+}

--- a/testdata/config/localClient.yaml
+++ b/testdata/config/localClient.yaml
@@ -9,3 +9,8 @@ logging:
   level: info
   location: stderr
   style: text
+class_options:
+  opt_out: true
+  opt_in: false
+  allow: []
+  deny: []


### PR DESCRIPTION
Add a telemetry package to the repo top-level directory that defines the client interfaces that should be used by applications integrating with the SUSE Telemetry Client to generate telemetry.

The telemetry package defines the following interfaces:
* Generate() - can be called by telemetry providers to "generate" telemetry.
* Status() - can be used by telemetry providers to check the status of the telemetry client.

Enhance the telemetry client config to support specifing enablement state for the opt-out and opt-in telemetry classes, and allow and deny lists for specific telemetry types.

Add new types and associated helper methods, to support the telemetry client interfaces:
* TelemetryClass - specifies mandatory, opt-out or opt-in classes of telemetry.
* GenerateFlags - flags that control how the Generate() interface handles provided telemetry.

Updated the examples directory contents, including adding an example Go app leveraging the telemetry client interfaces to generate telemetry and check the status of the telemetry client.

Updated various config files and embedded config settings to reflect recent logging support changes and add class_options settings; they should all now be pretty consistent in their content.

Updated the cmd/generator and cmd/clientds tools to setup logging.

Relates: #15 #30 #31 #32 #33