### PR TITLE
Finish switching from log to slog for telemetry client

### DIFF
--- a/cmd/clientds/main.go
+++ b/cmd/clientds/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	"log"
+	"log/slog"
 
 	"github.com/SUSE/telemetry/pkg/client"
 	"github.com/SUSE/telemetry/pkg/config"
@@ -34,7 +34,12 @@ func main() {
 
 	cfg, err := config.NewConfig(opts.config)
 	if err != nil {
-		log.Fatal(err)
+		slog.Error(
+			"Failed to load specified config",
+			slog.String("config", opts.config),
+			slog.String("Error", err.Error()),
+		)
+		panic(err)
 	}
 	fmt.Printf("Config: %+v\n", cfg)
 
@@ -48,7 +53,12 @@ func main() {
 
 	tc, err := client.NewTelemetryClient(cfg)
 	if err != nil {
-		log.Fatal(err)
+		slog.Error(
+			"Failed to instantiate TelemetryClient",
+			slog.String("config", opts.config),
+			slog.String("Error", err.Error()),
+		)
+		panic(err)
 	}
 
 	processor := tc.Processor()
@@ -56,7 +66,11 @@ func main() {
 	if opts.items {
 		itemRows, err := processor.GetItemRows()
 		if err != nil {
-			log.Fatal(err.Error())
+			slog.Error(
+				"Failed to retrieve items from client datastore",
+				slog.String("error", err.Error()),
+			)
+			panic(err)
 		}
 
 		itemCount := len(itemRows)
@@ -71,7 +85,11 @@ func main() {
 	if opts.bundles {
 		bundleRows, err := processor.GetBundleRows()
 		if err != nil {
-			log.Fatal(err.Error())
+			slog.Error(
+				"Failed to retrieve bundles from client datastore",
+				slog.String("error", err.Error()),
+			)
+			panic(err)
 		}
 
 		bundleCount := len(bundleRows)
@@ -86,7 +104,11 @@ func main() {
 	if opts.reports {
 		reportRows, err := processor.GetReportRows()
 		if err != nil {
-			log.Fatal(err.Error())
+			slog.Error(
+				"Failed to retrieve reports from client datastore",
+				slog.String("error", err.Error()),
+			)
+			panic(err)
 		}
 
 		reportCount := len(reportRows)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -3,7 +3,6 @@ package config
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"log/slog"
 	"os"
 	"slices"
@@ -94,7 +93,6 @@ func NewConfig(cfgFile string) (*Config, error) {
 		return cfg, fmt.Errorf("failed to read contents of config file '%s': %s", cfgFile, err)
 	}
 
-	log.Printf("Contents: %q", contents)
 	slog.Info("Contents", slog.String("contents", string(contents)))
 	err = yaml.Unmarshal(contents, &cfg)
 	if err != nil {

--- a/pkg/lib/bundles.go
+++ b/pkg/lib/bundles.go
@@ -2,7 +2,6 @@ package telemetrylib
 
 import (
 	"database/sql"
-	"log"
 	"log/slog"
 	"strings"
 
@@ -136,7 +135,12 @@ func (b *TelemetryBundleRow) Insert(db *sql.DB, itemIDs []int64) (bundleId strin
 	for _, itemID := range itemIDs {
 		_, err := db.Exec("UPDATE items SET bundleId = ? WHERE id = ?", b.Id, itemID)
 		if err != nil {
-			log.Fatal(err)
+			slog.Error(
+				"Failed to update bundleId in item",
+				slog.Int64("itemId", itemID),
+				slog.String("error", err.Error()),
+			)
+			return "", err
 		}
 	}
 

--- a/pkg/lib/limits.go
+++ b/pkg/lib/limits.go
@@ -2,7 +2,6 @@ package telemetrylib
 
 import (
 	"errors"
-	"log"
 	"log/slog"
 )
 
@@ -43,8 +42,7 @@ func (t *TelemetryDataLimits) GetTelemetryDataLimits() TelemetryDataLimits {
 // CheckLimits checks the telemetry data limits
 func (t *TelemetryDataLimits) CheckLimits(data []byte) error {
 	dataSize := uint64(len(data))
-	log.Println("Checking size limits for Telemetry Data")
-	slog.Info(
+	slog.Debug(
 		"Checking size limits for Telemetry Data",
 		slog.Uint64("Data size", dataSize),
 		slog.Uint64("Max", t.MaxSize),
@@ -58,7 +56,10 @@ func (t *TelemetryDataLimits) CheckLimits(data []byte) error {
 	case dataSize < t.MinSize:
 		return errors.New("payload size is below the minimum limit")
 	default:
-		slog.Info("Checks passed")
+		slog.Debug(
+			"Acceptable telemetry data size",
+			slog.Uint64("Data size", dataSize),
+		)
 		return nil
 	}
 }

--- a/pkg/lib/processor_test.go
+++ b/pkg/lib/processor_test.go
@@ -2,7 +2,7 @@ package telemetrylib
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	"strings"
 	"testing"
 
@@ -28,12 +28,20 @@ func NewProcessorTestEnv(cfgFile string) (*telemetryProcessorTestEnv, error) {
 func (t *telemetryProcessorTestEnv) setup() (err error) {
 	t.cfg, err = config.NewConfig(t.cfgPath)
 	if err != nil {
-		log.Print(err.Error())
+		slog.Error(
+			"Failed to load config",
+			slog.String("cfgPath", t.cfgPath),
+			slog.String("error", err.Error()),
+		)
 		return
 	}
 	processor, err := NewTelemetryProcessor(&t.cfg.DataStores)
 	if err != nil {
-		log.Printf("failed to setup telemetry processor for config %q: %s", t.cfgPath, err.Error())
+		slog.Error(
+			"Failed to setup telemetry processor",
+			slog.String("cfgPath", t.cfgPath),
+			slog.String("error", err.Error()),
+		)
 		return
 	}
 	t.telemetryprocessor = processor
@@ -130,7 +138,6 @@ func (t *TelemetryProcessorTestSuite) TestCreateBundle() {
 	bundleRow, berr := telemetryprocessor.GenerateBundle(1, "customer id", btags)
 
 	if berr != nil {
-		log.Printf("Failed to create the bundle")
 		t.Fail("Test failed to create the bundle")
 	}
 
@@ -208,7 +215,6 @@ func (t *TelemetryProcessorTestSuite) TestReport() {
 			btags := types.Tags{types.Tag("key1=value1"), types.Tag("key2")}
 			bundleRow, berr := telemetryprocessor.GenerateBundle(1, "customer id", btags)
 			if berr != nil {
-				log.Printf("Failed to create the bundle")
 				t.Fail("Test failed to create the bundle")
 			}
 
@@ -242,7 +248,6 @@ func (t *TelemetryProcessorTestSuite) TestReport() {
 			btags1 := types.Tags{types.Tag("key3=value3"), types.Tag("key4")}
 			bundleRow, berr = telemetryprocessor.GenerateBundle(1, "customer id", btags1)
 			if berr != nil {
-				log.Printf("Failed to create the bundle")
 				t.Fail("Test failed to create the bundle")
 			}
 
@@ -370,7 +375,11 @@ func addDataItems(totalItems int, processor TelemetryProcessor) error {
 		formattedJSON := fmt.Sprintf(payload, utils.GenerateRandomString(3))
 		err := processor.AddData(telemetryType, []byte(formattedJSON), tags)
 		if err != nil {
-			log.Printf("Failed to add the item %d", numItems)
+			slog.Error(
+				"Failed to add the item",
+				slog.Int("numItems", numItems),
+				slog.String("error", err.Error()),
+			)
 			return err
 		}
 

--- a/pkg/lib/reports.go
+++ b/pkg/lib/reports.go
@@ -2,7 +2,6 @@ package telemetrylib
 
 import (
 	"database/sql"
-	"log"
 	"log/slog"
 	"strings"
 
@@ -120,7 +119,12 @@ func (r *TelemetryReportRow) Insert(db *sql.DB, bundleIDs []int64) (reportId str
 	for _, bundleID := range bundleIDs {
 		_, err := db.Exec("UPDATE bundles SET ReportId = ? WHERE id = ?", r.Id, bundleID)
 		if err != nil {
-			log.Fatal(err)
+			slog.Error(
+				"Failed to update reportId in bundle",
+				slog.Int64("bundleId", bundleID),
+				slog.String("error", err.Error()),
+			)
+			return "", err
 		}
 	}
 	reportId = r.ReportId


### PR DESCRIPTION
Also converts log.Fatal() calls to slog.Error() followed by return in many cases, especially those within the internal packages of the telemetry client library.

Added missing checks for errors when decompressing data for item rows.

Defined named return values for some of the datastore methods to simplify error handling and return statements.

Minor other code cleanups.

Closes: #15