### PR TITLE
Add support for telemetry client (re-)authenticate request

### DIFF
--- a/cmd/clientds/main.go
+++ b/cmd/clientds/main.go
@@ -43,11 +43,19 @@ func main() {
 	}
 	fmt.Printf("Config: %+v\n", cfg)
 
+	// setup logging based upon config settings
 	lm := logging.NewLogManager()
-	if opts.debug {
-		lm.SetLevel("debug")
+	if err := lm.Config(&cfg.Logging); err != nil {
+		panic(err)
 	}
-	if err := lm.ConfigAndSetup(&cfg.Logging); err != nil {
+
+	// override config log level to debug if option specified
+	if opts.debug {
+		lm.SetLevel("DEBUG")
+		slog.Debug("Debug mode enabled")
+	}
+
+	if err := lm.Setup(); err != nil {
 		panic(err)
 	}
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -125,7 +125,7 @@ func (tc *TelemetryClient) InstIdPath() string {
 	return INSTANCEID_PATH
 }
 
-func (tc *TelemetryClient) getInstanceId() (instId []byte, err error) {
+func (tc *TelemetryClient) getInstanceId() (instId types.ClientInstanceId, err error) {
 	instIdPath := tc.InstIdPath()
 
 	err = ensureInstanceIdExists(instIdPath)
@@ -133,16 +133,23 @@ func (tc *TelemetryClient) getInstanceId() (instId []byte, err error) {
 		return
 	}
 
-	instId, err = os.ReadFile(instIdPath)
+	data, err := os.ReadFile(instIdPath)
 	if err != nil {
 		slog.Error(
 			"failed to read instId file",
-			slog.String("instIdPath", instIdPath),
+			slog.String("path", instIdPath),
 			slog.String("err", err.Error()),
 		)
-	} else {
-		slog.Info("successfully read instId file", slog.String("instId", string(instId)))
+		return
 	}
+
+	instId = types.ClientInstanceId((data))
+
+	slog.Debug(
+		"successfully read instId file",
+		slog.String("path", string(instIdPath)),
+		slog.String("instId", string(instId)),
+	)
 
 	return
 }
@@ -182,7 +189,7 @@ func (tc *TelemetryClient) loadTelemetryAuth() (err error) {
 		return
 	}
 
-	if tc.auth.ClientId == 0 {
+	if tc.auth.ClientId <= 0 {
 		err = fmt.Errorf("invalid client id")
 		slog.Error(
 			"invalid auth",
@@ -248,6 +255,7 @@ func (tc *TelemetryClient) submitReport(report *telemetrylib.TelemetryReport) (e
 
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Authorization", "Bearer "+tc.auth.Token.String())
+	req.Header.Add("X-Telemetry-Client-Id", fmt.Sprintf("%d", tc.auth.ClientId))
 
 	httpClient := http.DefaultClient
 	resp, err := httpClient.Do(req)
@@ -283,6 +291,115 @@ func (tc *TelemetryClient) submitReport(report *telemetrylib.TelemetryReport) (e
 	return
 }
 
+// Authenticate is responsible for (re)authenticating an already registered
+// client with the server to ensure that it's auth token is up to date.
+func (tc *TelemetryClient) Authenticate() (err error) {
+	if err = tc.loadTelemetryAuth(); err != nil {
+		return fmt.Errorf(
+			"telemetry client (re-)authentication requires an existing "+
+				"client registration: %s",
+			err.Error(),
+		)
+	}
+
+	// get the instanceId, failing if it can't be retrieved
+	instId, err := tc.getInstanceId()
+	if err != nil {
+		return
+	}
+
+	// assemble the authentication request
+	caReq := restapi.ClientAuthenticationRequest{
+		ClientId:   tc.auth.ClientId,
+		InstIdHash: *instId.Hash("default"),
+	}
+
+	reqBodyJSON, err := json.Marshal(&caReq)
+	if err != nil {
+		slog.Error(
+			"failed to JSON marshal caReq",
+			slog.String("err", err.Error()),
+		)
+		return
+	}
+
+	reqUrl := tc.cfg.TelemetryBaseURL + "/authenticate"
+	reqBuf := bytes.NewBuffer(reqBodyJSON)
+	req, err := http.NewRequest("POST", reqUrl, reqBuf)
+	if err != nil {
+		slog.Error(
+			"failed to create new HTTP request for client authentication",
+			slog.String("err", err.Error()),
+		)
+		return
+	}
+
+	req.Header.Add("Content-Type", "application/json")
+
+	httpClient := http.DefaultClient
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		slog.Error(
+			"failed to HTTP POST client authentication request",
+			slog.String("err", err.Error()),
+		)
+		return
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		slog.Error(
+			"failed to read client authentication response body",
+			slog.String("err", err.Error()),
+		)
+		return
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		err = fmt.Errorf("client authentication failed: %s", string(respBody))
+		return
+	}
+
+	var caResp restapi.ClientAuthenticationResponse
+	err = json.Unmarshal(respBody, &caResp)
+	if err != nil {
+		slog.Error(
+			"failed to JSON unmarshal client authentication response body content",
+			slog.String("err", err.Error()),
+		)
+		return
+	}
+
+	tc.auth.ClientId = caResp.ClientId
+	tc.auth.Token = types.TelemetryAuthToken(caResp.AuthToken)
+	tc.auth.IssueDate, err = types.TimeStampFromString(caResp.IssueDate)
+	if err != nil {
+		slog.Error(
+			"failed to parse issueDate as a timestamp",
+			slog.String("issueDate", caResp.IssueDate),
+			slog.String("err", err.Error()),
+		)
+		return
+	}
+
+	err = tc.saveTelemetryAuth()
+	if err != nil {
+		slog.Error(
+			"failed to save TelemetryAuth",
+			slog.String("err", err.Error()),
+		)
+		return
+	}
+
+	slog.Info(
+		"successfully authenticated",
+		slog.Int64("clientId", tc.auth.ClientId),
+	)
+
+	return
+}
+
 func (tc *TelemetryClient) Register() (err error) {
 	// get the saved TelemetryAuth, returning success if found
 	err = tc.loadTelemetryAuth()
@@ -299,7 +416,7 @@ func (tc *TelemetryClient) Register() (err error) {
 
 	// register the system as a client
 	var crReq restapi.ClientRegistrationRequest
-	crReq.ClientInstanceId = string(instId)
+	crReq.ClientInstanceId = instId
 	reqBodyJSON, err := json.Marshal(&crReq)
 	if err != nil {
 		slog.Error(

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -93,7 +93,7 @@ func NewConfig(cfgFile string) (*Config, error) {
 		return cfg, fmt.Errorf("failed to read contents of config file '%s': %s", cfgFile, err)
 	}
 
-	slog.Info("Contents", slog.String("contents", string(contents)))
+	slog.Debug("Contents", slog.String("contents", string(contents)))
 	err = yaml.Unmarshal(contents, &cfg)
 	if err != nil {
 		return cfg, fmt.Errorf("failed to parse contents of config file '%s': %s", cfgFile, err)

--- a/pkg/lib/processor.go
+++ b/pkg/lib/processor.go
@@ -98,7 +98,7 @@ func (p *TelemetryProcessorImpl) DeleteReport(reportRow *TelemetryReportRow) (er
 var _ TelemetryProcessor = (*TelemetryProcessorImpl)(nil)
 
 func NewTelemetryProcessor(cfg *config.DBConfig) (TelemetryProcessor, error) {
-	slog.Info("NewTelemetryProcessor", slog.Any("cfg", cfg))
+	slog.Debug("NewTelemetryProcessor", slog.Any("cfg", cfg))
 	p := TelemetryProcessorImpl{cfg: cfg}
 
 	err := p.setup(cfg)

--- a/pkg/restapi/restapi.go
+++ b/pkg/restapi/restapi.go
@@ -14,7 +14,7 @@ import (
 
 // ClientRegistrationRequest is the request payload body POST'd to the server
 type ClientRegistrationRequest struct {
-	ClientInstanceId string `json:"clientInstanceId"`
+	ClientInstanceId types.ClientInstanceId `json:"clientInstanceId"`
 }
 
 func (c *ClientRegistrationRequest) String() string {
@@ -35,6 +35,22 @@ func (c *ClientRegistrationResponse) String() string {
 
 	return string(bytes)
 }
+
+// Client Authenticate handling via /temelemtry/authenticate
+type ClientAuthenticationRequest struct {
+	ClientId   int64                      `json:"clientId"`
+	InstIdHash types.ClientInstanceIdHash `json:"instIdHash"`
+}
+
+func (c *ClientAuthenticationRequest) String() string {
+	bytes, _ := json.Marshal(c)
+
+	return string(bytes)
+}
+
+// for now the /authenticate response is the same as the /register
+// response
+type ClientAuthenticationResponse = ClientRegistrationResponse
 
 //
 // Client Telemetry Report via /telemetry/report POST


### PR DESCRIPTION
Define the over the wire representations for the /authenticate request and response data structures. The request sends the existing clientId and the SHA256 hash of the client's InstanceID, and gets back a similar response to the /register request.

Add an Authenticate() method to the TelemetryClient that leverages the new request to retrieve an update authentication bundle.

Add options to cmd/generator to allow control of whether registration or authentication is performed.

Fix cmd/generator and cmd/clientds debug override setup to work correctly.

Switch some slog messages from Info to Debug level.