### PR TITLE
Define a TelemetryBlob type to hold JSON blobs

### DIFF
--- a/pkg/limits/limits.go
+++ b/pkg/limits/limits.go
@@ -1,4 +1,4 @@
-package telemetrylib
+package limits
 
 import (
 	"errors"

--- a/pkg/types/blob.go
+++ b/pkg/types/blob.go
@@ -1,0 +1,70 @@
+package types
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	"github.com/SUSE/telemetry/pkg/limits"
+)
+
+type TelemetryBlob struct {
+	bytes []byte
+}
+
+func NewTelemetryBlob(jsonBlob []byte) *TelemetryBlob {
+	return &TelemetryBlob{bytes: jsonBlob}
+}
+
+func (tb *TelemetryBlob) String() string {
+	return string(tb.bytes)
+}
+
+func (tb *TelemetryBlob) Bytes() []byte {
+	return tb.bytes
+}
+
+func (tb *TelemetryBlob) errNotValidJson() error {
+	return fmt.Errorf("not valid JSON blob")
+}
+
+func (tb *TelemetryBlob) errNotJsonObject(err error) error {
+	return fmt.Errorf("not a JSON object: %s", err.Error())
+}
+
+func (tb *TelemetryBlob) errNotVersionedObject() error {
+	return fmt.Errorf("missing 'version' field in JSON object")
+}
+
+func (tb *TelemetryBlob) validJson() bool {
+	return json.Valid(tb.Bytes())
+}
+
+func (tb *TelemetryBlob) Valid() error {
+	var data map[string]any
+
+	if !tb.validJson() {
+		return tb.errNotValidJson()
+	}
+
+	if err := json.Unmarshal(tb.Bytes(), &data); err != nil {
+		slog.Debug(
+			"Not a valid JSON object",
+			slog.String("blob", tb.String()),
+			slog.String("error", err.Error()),
+		)
+		newErr := tb.errNotJsonObject(err)
+		return newErr
+	}
+
+	if _, found := data["version"]; !found {
+		slog.Debug("Not a valid JSON object", slog.String("blob", tb.String()))
+		return tb.errNotVersionedObject()
+	}
+
+	return nil
+}
+
+func (tb *TelemetryBlob) CheckLimits() error {
+	return limits.NewTelemetryDataLimits().CheckLimits(tb.Bytes())
+}

--- a/telemetry.go
+++ b/telemetry.go
@@ -57,6 +57,9 @@ func Generate(telemetry types.TelemetryType, class TelemetryClass, content []byt
 		return err
 	}
 
+	// check that the telemetry content is valid
+	blob := types.NewTelemetryBlob(content)
+
 	// attempt to load the default config file
 	cfg, err := config.NewConfig(client.CONFIG_PATH)
 	if err != nil {
@@ -113,7 +116,7 @@ func Generate(telemetry types.TelemetryType, class TelemetryClass, content []byt
 	}
 
 	// generate the telemetry, storing it in the local data store
-	err = tc.Generate(telemetry, content, tags)
+	err = tc.Generate(telemetry, blob, tags)
 	if err != nil {
 		slog.Warn(
 			"Failed to generate telemetry",


### PR DESCRIPTION
The TelemetryBlob type provides helper methods that can be used to validate that provided blobs are:
* Valid JSON
* JSON objects
* Contain a top-level "version" field
* Are not too big.

The validity of provided JSON blobs is checked when they are received via a Generate() interface.

Also update client side item handling to leverage the json.RawMessage type for storing the JSON blobs; this avoid undesirable processing of the provided JSON blob data, which should remain untouched en-route to long term storage in the SUSE Telemetry service.

Minor restructuring of the client side library, moving limits to it's own subpackage to avoid an import loop when adding the CheckLimits() helper method to the TelemetryBlob.

Fixes: #41, #26