### PR TITLE
Implement a ManagedFile type

### DIFF
--- a/Makefile.golang
+++ b/Makefile.golang
@@ -1,3 +1,5 @@
+COVERAGE_PROFILE=/tmp/.coverage.telemetry.out
+
 .DEFAULT_GOAL := build
 
 .PHONY: fmt vet build build-only clean test-clean test-verbose
@@ -23,7 +25,8 @@ test: test-clean build
 	go test -cover ./...
 
 test-verbose: test-clean build
-	go test -v -cover ./...
+	go test -v -cover -coverprofile=$(COVERAGE_PROFILE) ./... && \
+	go tool cover --func=$(COVERAGE_PROFILE)
 
 tidy:
 	go mod tidy

--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ The verification tests can be run from within the telemetry repo as follows:
 % make test
 ```
 
+For a more detailed test run, including coverage details, the test-verbose
+target can be used:
+
+```
+% cd telemetry
+% make test-verbose
+```
+
 ## Local Developer Testing
 First ensure that the SUSE/telemetry-server is running with the local
 server config file. Then run the cmd/generator tool from the telemetry

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -521,7 +521,7 @@ func (tc *TelemetryClient) Generate(telemetry types.TelemetryType, content *type
 func (tc *TelemetryClient) CreateBundles(tags types.Tags) error {
 	// Bundle existing telemetry data items found in DataItem data store into one or more bundles in the Bundle data store
 	slog.Debug("Bundle", slog.String("Tags", tags.String()))
-	tc.processor.GenerateBundle(tc.ClientId(), tc.cfg.CustomerID, tags)
+	tc.processor.GenerateBundle(tc.ClientId(), tc.cfg.CustomerId, tags)
 
 	return nil
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -22,7 +22,8 @@ func (t *TestConfigTestSuite) TestConfigFileNotFound() {
 
 	assert.Equal(t.T(), DefaultCfg.TelemetryBaseURL, config.TelemetryBaseURL, "TelemetryBaseURL value is not the expected")
 	assert.Equal(t.T(), DefaultCfg.Enabled, config.Enabled, "Enabled value is not the expected")
-	assert.Equal(t.T(), DefaultCfg.CustomerID, config.CustomerID, "CustomerID value is not the expected")
+	assert.Equal(t.T(), DefaultCfg.ClientId, config.ClientId, "ClientId value is not the expected")
+	assert.Equal(t.T(), DefaultCfg.CustomerId, config.CustomerId, "CustomerId value is not the expected")
 	assert.Equal(t.T(), DefaultCfg.Tags, config.Tags, "Tags value is not the expected")
 	assert.Equal(t.T(), DefaultCfg.DataStores.Driver, config.DataStores.Driver, "DataStores.Driver is not the expected")
 	assert.Equal(t.T(), DefaultCfg.DataStores.Params, config.DataStores.Params, "DataStores.Params is not the expected")

--- a/pkg/utils/managed_file.go
+++ b/pkg/utils/managed_file.go
@@ -1,0 +1,736 @@
+package utils
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"log/slog"
+	"os"
+	os_user "os/user"
+	"path/filepath"
+	"strconv"
+	"syscall"
+)
+
+func getUserInfo(u string) (user *os_user.User, err error) {
+	// use current user if no user specified
+	if u == "" {
+		return os_user.Current()
+	}
+
+	// first attempt to lookup user by name
+	user, lname_err := os_user.Lookup(u)
+	if lname_err == nil {
+		return
+	}
+
+	slog.Debug(
+		"Lookup() failed",
+		slog.String("user", u),
+		slog.String("err", lname_err.Error()),
+	)
+
+	// next try to lookup user by id
+	user, lid_err := os_user.LookupId(u)
+	if lid_err == nil {
+		return
+	}
+
+	slog.Debug(
+		"LookupId() failed",
+		slog.String("uid", u),
+		slog.String("err", lid_err.Error()),
+	)
+
+	err = fmt.Errorf("failed to retrieve user by name (%w) or id (%w)", lname_err, lid_err)
+	return
+}
+
+func getGroupInfo(g string) (group *os_user.Group, err error) {
+	skip_group_lookup := false
+	var lname_err, lid_err error
+
+	// use current user's primary group if no group specified
+	if g == "" {
+		user, err := os_user.Current()
+		if err != nil {
+			return nil, err
+		}
+
+		g = user.Gid
+
+		// using primary gid so skip lookup by group name
+		skip_group_lookup = true
+	}
+
+	if !skip_group_lookup {
+		// first attempt to lookup group by name
+		group, lname_err = os_user.LookupGroup(g)
+		if lname_err == nil {
+			return
+		}
+
+		slog.Debug(
+			"LookupGroup() failed",
+			slog.String("group", g),
+			slog.String("err", lname_err.Error()),
+		)
+	}
+
+	// next try to lookup group by id
+	group, lid_err = os_user.LookupGroupId(g)
+	if lid_err == nil {
+		return
+	}
+
+	slog.Debug(
+		"LookupGroupId() failed",
+		slog.String("gid", g),
+		slog.String("err", lid_err.Error()),
+	)
+
+	err = fmt.Errorf("failed to retrieve group by name (%w) or id (%w)", lname_err, lid_err)
+	return
+}
+
+// mockable os interface
+type mockableOs interface {
+	OpenFile(name string, flag int, perm os.FileMode) (*os.File, error)
+	Remove(name string) error
+	Stat(name string) (os.FileInfo, error)
+}
+
+type realOs struct{}
+
+// call real os.OpenFile()
+func (r *realOs) OpenFile(name string, flag int, perm os.FileMode) (*os.File, error) {
+	return os.OpenFile(name, flag, perm)
+}
+
+// call real os.Remove()
+func (r *realOs) Remove(name string) error {
+	return os.Remove(name)
+}
+
+// call real os.Stat()
+func (r *realOs) Stat(name string) (os.FileInfo, error) {
+	return os.Stat(name)
+}
+
+var _ mockableOs = (*realOs)(nil)
+
+// mockable syscall interface
+type mockableSyscall interface {
+	Flock(fd int, how int) (err error)
+}
+
+type realSyscall struct{}
+
+func (r *realSyscall) Flock(fd int, how int) (err error) {
+	return syscall.Flock(fd, how)
+}
+
+var _ mockableSyscall = (*realSyscall)(nil)
+
+// FileManager interface
+type FileManager interface {
+	// init the structure
+	Init(path string, owner string, group string, perm os.FileMode) error
+
+	// file path
+	Path() string
+	SetPath(path string) error
+	Exists() (bool, error)
+
+	// file ownership and permissions
+	User() string
+	SetUser(string) error
+	Group() string
+	SetGroup(string) error
+	Perm() os.FileMode
+	SetPerm(perm os.FileMode) error
+
+	// lock management
+	Lock() error
+	Unlock() error
+	IsLocked() bool
+
+	// data operations
+	Create() error
+	Read() ([]byte, error)
+	Update(updatedContent []byte) error
+	Backup() error
+	Delete() error
+	Close() error
+}
+
+// ManagedFile
+type ManagedFile struct {
+	os      mockableOs      // normally the os module, replaceable for testing purposes
+	syscall mockableSyscall // normally the syscall module, replaceable for testing purposes
+	path    string
+	user    *os_user.User
+	group   *os_user.Group
+	perm    os.FileMode
+	locked  bool
+	file    *os.File
+}
+
+func NewManagedFile() *ManagedFile {
+	return &ManagedFile{
+		os:      &realOs{},
+		syscall: &realSyscall{},
+	}
+}
+
+func (fm *ManagedFile) dbg(msg string) {
+	slog.Debug(
+		msg,
+		slog.String("path", fm.path),
+	)
+}
+
+func (fm *ManagedFile) dbg_with_err(msg string, err error) error {
+	slog.Debug(
+		msg,
+		slog.String("path", fm.path),
+		slog.String("err", err.Error()),
+	)
+
+	return err
+}
+
+func (fm *ManagedFile) err_with_err(msg string, err error) error {
+	slog.Error(
+		msg,
+		slog.String("path", fm.path),
+		slog.String("err", err.Error()),
+	)
+
+	return err
+}
+
+func (fm *ManagedFile) checkPath() (err error) {
+	if fm.path == "" {
+		err = fmt.Errorf("managed file path not setup")
+		fm.dbg_with_err("managed file not setup", err)
+	}
+	return
+}
+
+func (fm *ManagedFile) Init(path, user, group string, perm os.FileMode) (err error) {
+	if err = fm.SetPerm(perm); err != nil {
+		return
+	}
+	if err = fm.SetUser(user); err != nil {
+		return
+	}
+	if err = fm.SetGroup(group); err != nil {
+		return
+	}
+	if err = fm.SetPath(path); err != nil {
+		return
+	}
+	fm.locked = false
+
+	return
+}
+
+func (fm *ManagedFile) Path() string {
+	return fm.path
+}
+
+func (fm *ManagedFile) SetPath(path string) (err error) {
+	if !filepath.IsAbs(path) {
+		return fm.dbg_with_err(
+			fmt.Sprintf("non-absolute path: %q", path),
+			fmt.Errorf("managed file paths must be absolute"),
+		)
+	}
+
+	if fm.file != nil {
+		if err = fm.Close(); err != nil {
+			return fm.err_with_err("failed to close existing file", err)
+		}
+	}
+
+	fm.path = path
+	return
+}
+
+func (fm *ManagedFile) Exists() (exists bool, err error) {
+	if err = fm.checkPath(); err != nil {
+		return
+	}
+
+	fm.dbg("checking if managed file exists")
+
+	if _, err = fm.os.Stat(fm.path); err == nil {
+		// stat succeeded so file exists
+		exists = true
+	} else if errors.Is(err, fs.ErrNotExist) {
+		// stat failed because file doesn't exists
+		err = nil
+	} else {
+		fm.dbg_with_err("failed to stat file", err)
+	}
+
+	return
+}
+
+// idStr2int32() parses a uid or gid string to an int32
+func idStr2int32(idName, idStr string) (res int32, err error) {
+	// the idStr should be a base 10 representation of an int32 value
+	parsed, err := strconv.ParseInt(idStr, 10, 32)
+	if err != nil {
+		slog.Debug(
+			fmt.Sprintf("failed to parse %s as an int", idName),
+			slog.String(idName, idStr),
+			slog.String("err", err.Error()),
+		)
+		err = fmt.Errorf(
+			"failed to parse %v %q as a 32-bit int: %w",
+			idName,
+			idStr,
+			err,
+		)
+		return
+	}
+
+	res = int32(parsed)
+
+	return
+}
+
+func (fm *ManagedFile) chownFile(file *os.File) (err error) {
+	path := file.Name()
+
+	slog.Debug(
+		"chown()ing file",
+		slog.String("path", path),
+		slog.String("uid", fm.user.Uid),
+		slog.String("gid", fm.group.Gid),
+	)
+
+	uid, err := idStr2int32("uid", fm.user.Uid)
+	if err != nil {
+		return
+	}
+
+	gid, err := idStr2int32("gid", fm.group.Gid)
+	if err != nil {
+		return
+	}
+
+	if err = file.Chown(int(uid), int(gid)); err != nil {
+		slog.Error(
+			"chown() failed",
+			slog.String("path", path),
+			slog.String("uid", fm.user.Uid),
+			slog.String("gid", fm.group.Gid),
+			slog.String("err", err.Error()),
+		)
+		err = fmt.Errorf(
+			"chown(%q, %v, %v) failed: %w",
+			path,
+			fm.user.Uid,
+			fm.group.Gid,
+			err,
+		)
+	}
+
+	return
+}
+
+func (fm *ManagedFile) chown() (err error) {
+	// can't update existing file ownership if we don't have
+	// an open file, and user and group info
+	if (fm.file == nil) || (fm.user == nil) || (fm.group == nil) {
+		return
+	}
+
+	// chown the opened file
+	return fm.chownFile(fm.file)
+}
+
+func (fm *ManagedFile) User() string {
+	return fm.user.Username
+}
+
+func (fm *ManagedFile) SetUser(user string) (err error) {
+	if fm.user, err = getUserInfo(user); err != nil {
+		slog.Error(
+			"failed to get user info",
+			slog.String("user", user),
+			slog.String("err", err.Error()),
+		)
+		return
+	}
+
+	// update ownership of existing file if appropriate
+	return fm.chown()
+}
+
+func (fm *ManagedFile) Group() string {
+	return fm.group.Name
+}
+
+func (fm *ManagedFile) SetGroup(group string) (err error) {
+	if fm.group, err = getGroupInfo(group); err != nil {
+		slog.Error(
+			"failed to get group info",
+			slog.String("group", group),
+			slog.String("err", err.Error()),
+		)
+		return
+	}
+
+	// update ownership of existing file if appropriate
+	return fm.chown()
+}
+
+func checkViablePerm(perm os.FileMode) (err error) {
+	if (perm & os.ModePerm) == 0 {
+		err = fmt.Errorf("disabling all access permissions is not recommended")
+	}
+
+	return
+}
+
+func (fm *ManagedFile) checkPerm() (err error) {
+	if err = checkViablePerm(fm.perm); err != nil {
+		err = fm.err_with_err("failed viable permissions check", err)
+	}
+
+	return
+}
+
+func (fm *ManagedFile) chmod() (err error) {
+	if fm.file == nil {
+		return
+	}
+
+	if err = fm.checkPath(); err != nil {
+		return
+	}
+
+	if err = fm.file.Chmod(fm.perm); err != nil {
+		slog.Debug(
+			"failed to chmod file to new permissions",
+			slog.String("path", fm.path),
+			slog.String("perm", fm.perm.String()),
+			slog.String("err", err.Error()),
+		)
+		err = fmt.Errorf(
+			"failed to chmod(%q, %s): %w",
+			fm.path,
+			fm.perm.String(),
+			err,
+		)
+	}
+
+	return
+}
+
+func (fm *ManagedFile) Perm() os.FileMode {
+	return fm.perm
+}
+
+func (fm *ManagedFile) SetPerm(perm os.FileMode) (err error) {
+	if err = checkViablePerm(perm); err != nil {
+		return err
+	}
+
+	fm.perm = perm
+
+	return fm.chmod()
+}
+
+func (fm *ManagedFile) managedFileOperationFailed(op string, err error) error {
+	slog.Debug(
+		"managed file operation failed",
+		slog.String("operation", op),
+		slog.String("path", fm.path),
+		slog.String("err", err.Error()),
+	)
+
+	return err
+}
+
+func (fm *ManagedFile) Lock() (err error) {
+	if err = fm.checkPath(); err != nil {
+		return fm.managedFileOperationFailed("lock", err)
+	}
+
+	if err = fm.syscall.Flock(int(fm.file.Fd()), syscall.LOCK_EX); err != nil {
+		return fm.dbg_with_err("failed to lock file", err)
+	}
+
+	fm.locked = true
+
+	return
+}
+
+func (fm *ManagedFile) Unlock() (err error) {
+	if err = fm.checkPath(); err != nil {
+		return fm.managedFileOperationFailed("unlock", err)
+	}
+
+	if err = fm.syscall.Flock(int(fm.file.Fd()), syscall.LOCK_UN); err != nil {
+		return fm.dbg_with_err("failed to lock file", err)
+	}
+
+	fm.locked = false
+
+	return
+}
+
+func (fm *ManagedFile) IsLocked() bool {
+	return fm.locked
+}
+
+func (fm *ManagedFile) openCreate(path string, perm os.FileMode) (file *os.File, err error) {
+	var created bool
+
+	// in general we expect the file to already exist, so first try to open
+	// it for read + write access without creating it.
+	file, err = fm.os.OpenFile(
+		path,
+		os.O_RDWR,
+		perm,
+	)
+
+	// if the file doesn't already exist, attempt to create it
+	if err != nil && errors.Is(err, fs.ErrNotExist) {
+		fm.dbg_with_err("file doesn't exist, creating it", err)
+
+		file, err = fm.os.OpenFile(
+			path,
+			os.O_CREATE|os.O_RDWR,
+			perm,
+		)
+
+		// we created it if there was no failure
+		if err == nil {
+			created = true
+		}
+	}
+
+	// if we created the file, set it's ownership
+	if created {
+
+		if err = fm.chownFile(file); err != nil {
+			fm.err_with_err("failed to set ownership for created file", err)
+		}
+	}
+
+	if err != nil && file != nil {
+		// on error ensure we close any file that we created
+		file.Close()
+		file = nil
+	}
+
+	return
+}
+
+func (fm *ManagedFile) Create() (err error) {
+	if err = fm.checkPath(); err != nil {
+		return fm.managedFileOperationFailed("create", err)
+	}
+
+	// ensure that we create files that will be accessible
+	if err = fm.checkPerm(); err != nil {
+		return
+	}
+
+	// if there is an existing file close it, will be reopened below
+	if fm.file != nil {
+		close_err := fm.Close()
+		fm.dbg_with_err("failed to close existing file during create", close_err)
+	}
+
+	// attempt to open the file, creating it if needed
+	fm.file, err = fm.openCreate(
+		fm.path,
+		fm.perm,
+	)
+
+	// fail if we couldn't open the file successfully
+	if err != nil {
+		return fm.err_with_err("failed to create and open file", err)
+	}
+
+	return
+}
+
+func (fm *ManagedFile) backupFileName() string {
+	return fmt.Sprintf("%s.bak", fm.path)
+}
+
+func (fm *ManagedFile) Backup() (err error) {
+	if err = fm.checkPath(); err != nil {
+		return fm.managedFileOperationFailed("backup", err)
+	}
+
+	exists, err := fm.Exists()
+	if err != nil {
+		return fm.err_with_err(
+			"failed to backup file",
+			fmt.Errorf("unable to determine if file exists"),
+		)
+	}
+	if !exists {
+		return fm.dbg_with_err(
+			"failed to backup file",
+			fmt.Errorf("file doesn't exist yet"),
+		)
+	}
+
+	bkupName := fm.backupFileName()
+	bkup, err := fm.openCreate(bkupName, fm.perm.Perm())
+	if err != nil {
+		return fm.err_with_err("failed to create backup", err)
+	}
+	defer bkup.Close()
+
+	// file should be locked for the duration of the backup
+	if !fm.IsLocked() {
+		if err := fm.Lock(); err != nil {
+			return fm.dbg_with_err("failed to lock file for backup", err)
+		}
+		defer fm.Unlock()
+	}
+
+	// ensure we are at start of file
+	if _, err = fm.file.Seek(0, 0); err != nil {
+		return fm.err_with_err("failed to seek to file start", err)
+	}
+
+	// ensure we truncate the backup file
+	if err = bkup.Truncate(0); err != nil {
+		return fm.err_with_err("failed to backup file", err)
+	}
+
+	// ensure we are at start of backup file
+	if _, err = bkup.Seek(0, 0); err != nil {
+		return fm.err_with_err("failed to seek to backup file start", err)
+	}
+
+	// backup file contents
+	length, err := io.Copy(bkup, fm.file)
+	if err != nil {
+		return fm.err_with_err("failed to backup file", err)
+	}
+
+	slog.Debug(
+		"backed up file",
+		slog.String("path", fm.path),
+		slog.String("backup", bkupName),
+		slog.Int64("length", length),
+	)
+
+	return
+}
+
+func (fm *ManagedFile) Update(updatedContent []byte) (err error) {
+	if err = fm.checkPath(); err != nil {
+		return fm.managedFileOperationFailed("update", err)
+	}
+
+	// file should be locked for the duration of the read
+	if !fm.IsLocked() {
+		if err := fm.Lock(); err != nil {
+			return fm.dbg_with_err("failed to lock file for update", err)
+		}
+		defer fm.Unlock()
+	}
+
+	// truncate the existing file content
+	if err = fm.file.Truncate(0); err != nil {
+		return fm.err_with_err("failed to truncate file", err)
+	}
+
+	// ensure we are at start of file
+	if _, err = fm.file.Seek(0, 0); err != nil {
+		return fm.err_with_err("failed to seek to file start", err)
+	}
+
+	// write the updated content
+	if _, err = fm.file.Write(updatedContent); err != nil {
+		return fm.err_with_err("failed to update file", err)
+	}
+
+	// ensure written data is flushed to disk
+	if err = fm.file.Sync(); err != nil {
+		return fm.err_with_err("failed to flush updates to disk", err)
+	}
+
+	return
+}
+
+func (fm *ManagedFile) Read() (content []byte, err error) {
+	if err = fm.checkPath(); err != nil {
+		return nil, fm.managedFileOperationFailed("read", err)
+	}
+
+	// file should be locked for the duration of the read
+	if !fm.IsLocked() {
+		if err := fm.Lock(); err != nil {
+			return nil, fm.dbg_with_err("failed to lock file for read", err)
+		}
+		defer fm.Unlock()
+	}
+
+	// ensure we are at start of file
+	if _, err = fm.file.Seek(0, 0); err != nil {
+		return nil, fm.err_with_err("failed to seek to file start", err)
+	}
+
+	return io.ReadAll(fm.file)
+}
+
+func (fm *ManagedFile) Delete() (err error) {
+	if err = fm.checkPath(); err != nil {
+		return fm.managedFileOperationFailed("delete", err)
+	}
+
+	if err = fm.Close(); err != nil {
+		return fm.managedFileOperationFailed("delete", err)
+	}
+
+	if err = fm.os.Remove(fm.path); err != nil {
+		return fmt.Errorf(
+			"failed to remove file %q: %w",
+			fm.path,
+			fm.dbg_with_err("failed to remove file", err),
+		)
+	}
+
+	return
+}
+
+func (fm *ManagedFile) Close() (err error) {
+	if err = fm.checkPath(); err != nil {
+		return fm.managedFileOperationFailed("close", err)
+	}
+
+	if fm.locked {
+		return fm.Unlock()
+	}
+
+	if fm.file != nil {
+		if err = fm.file.Close(); err != nil {
+			return fmt.Errorf(
+				"failed to close file %q: %w",
+				fm.path,
+				fm.dbg_with_err("failed to close file", err),
+			)
+		}
+		fm.file = nil
+	}
+
+	return
+}
+
+var _ FileManager = (*ManagedFile)(nil)

--- a/pkg/utils/managed_file_test.go
+++ b/pkg/utils/managed_file_test.go
@@ -1,0 +1,774 @@
+package utils
+
+import (
+	"io/fs"
+	"os"
+	os_user "os/user"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type FileManagerTestSuite struct {
+	suite.Suite
+	user   *os_user.User
+	group  *os_user.Group
+	tmpDir string
+}
+
+func (t *FileManagerTestSuite) SetupSuite() {
+	currUser, err := os_user.Current()
+	t.NoError(err, "os/user.Current()")
+	t.NotNil(currUser, "currUser")
+	t.user = currUser
+
+	currGroup, err := os_user.LookupGroupId(currUser.Gid)
+	t.NoError(err, "os/user.LookupGroupId(currUser.Gid)")
+	t.NotNil(currGroup, "currGroup")
+	t.group = currGroup
+}
+
+func (t *FileManagerTestSuite) TearDownSuite() {
+}
+
+func (t *FileManagerTestSuite) SetupTest() {
+	tmpDir, err := os.MkdirTemp("", ".fileMgrTest.*")
+	t.NoError(err, "os.MkdirTemp()")
+
+	t.tmpDir = tmpDir
+	t.NotEmpty(t.tmpDir, "tmpDir should be setup")
+}
+
+func (t *FileManagerTestSuite) TearDownTest() {
+	err := os.RemoveAll(t.tmpDir)
+	t.NoError(err, "os.RemoveAll(t.tmpDir)")
+}
+
+func (t *FileManagerTestSuite) SkipIfRoot() {
+	if os.Geteuid() == 0 {
+		t.T().Skipf("Test cannot be run as root")
+	}
+}
+
+func (t *FileManagerTestSuite) Test_PathMustBeAbsolute() {
+	// use a common test file path
+	filename := filepath.Join(t.tmpDir, "test_file")
+
+	fm := NewManagedFile()
+	defer fm.Close()
+
+	// relative path
+	err := fm.Init(
+		"test_file",
+		"",
+		"",
+		0600,
+	)
+	t.Error(err, "fm.Init() with relative path")
+
+	// absolute path
+	err = fm.Init(
+		filename,
+		"",
+		"",
+		0600,
+	)
+	t.NoError(err, "fm.Init() with absolute path")
+}
+
+func (t *FileManagerTestSuite) Test_InitUserGroup() {
+	// use a common test file path
+	filename := filepath.Join(t.tmpDir, "test_file")
+
+	// define tests table
+	tests := []struct {
+		name                   string
+		path                   string
+		user                   string
+		group                  string
+		perm                   os.FileMode
+		expected_user_success  bool
+		expected_username      string
+		expected_username_msg  string
+		expected_group_success bool
+		expected_groupname     string
+		expected_groupname_msg string
+	}{
+		{
+			"default user and group",
+			filename,
+			"",
+			"",
+			0600,
+			true,
+			t.user.Username,
+			"default user should be the current user",
+			true,
+			t.group.Name,
+			"default group should be the current user's primary group",
+		},
+		{
+			"root user and group by name",
+			filename,
+			"root",
+			"root",
+			0600,
+			true,
+			"root",
+			"should be the root user",
+			true,
+			"root",
+			"should be the root group",
+		},
+		{
+			"root user and group by id",
+			filename,
+			"0",
+			"0",
+			0600,
+			true,
+			"root",
+			"should be the root user",
+			true,
+			"root",
+			"should be the root group",
+		},
+		{
+			"unknown user should fail",
+			filename,
+			"unknown",
+			"root",
+			0600,
+			false,
+			"unknown",
+			"should be an unknown user",
+			true,
+			"root",
+			"should be the root group",
+		},
+		{
+			"unknown group should fail",
+			filename,
+			"root",
+			"unknown",
+			0600,
+			true,
+			"root",
+			"should be the root user",
+			false,
+			"unknown",
+			"should be an unknown group",
+		},
+	}
+
+	// run the test for each test table entry
+	for _, tt := range tests {
+		t.Run(
+			"InitUserGroup "+tt.name,
+			func() {
+				fm := NewManagedFile()
+				defer fm.Close()
+
+				// test default user
+				err := fm.Init(
+					tt.path,
+					tt.user,
+					tt.group,
+					tt.perm,
+				)
+				if !(tt.expected_user_success && tt.expected_group_success) {
+					t.Error(err, "fm.Init() failed: %s", tt.name)
+					return
+				}
+
+				t.NoError(err, "fm.Init()")
+
+				t.NotEmpty(fm.user, "fm.user should be setup")
+				t.Equal(tt.expected_username, fm.User(), tt.expected_username_msg)
+
+				t.NotEmpty(fm.group, "fm.group should be setup")
+				t.Equal(tt.expected_groupname, fm.Group(), tt.expected_groupname_msg)
+			},
+		)
+	}
+}
+
+func (t *FileManagerTestSuite) Test_InitPerm() {
+	fm := NewManagedFile()
+	defer fm.Close()
+
+	path := filepath.Join(t.tmpDir, "test_file")
+	perm := os.FileMode(0600)
+
+	// absolute path
+	err := fm.Init(
+		path,
+		"",
+		"",
+		perm,
+	)
+	t.NoError(err, "fm.Init()")
+
+	t.NotEmpty(fm.perm, "fm.perm should be setup")
+	t.Equal(path, fm.Path(), "fm.Path() should be supplied perm")
+	t.Equal(perm, fm.Perm(), "fm.Perm() should be supplied perm")
+}
+
+func (t *FileManagerTestSuite) Test_CreateCloseDelete() {
+	fm := NewManagedFile()
+	defer fm.Close()
+
+	err := fm.Init(
+		filepath.Join(t.tmpDir, "test_file"),
+		"",
+		"",
+		0600,
+	)
+	t.NoError(err, "fm.Init()'d")
+
+	// create the file
+	err = fm.Create()
+	t.NoError(err, "create managed file")
+
+	// created file should exist
+	exists, err := fm.Exists()
+	t.NoError(err, "created file should exist")
+	t.True(exists, "created file should exist")
+
+	// explicitly close the file
+	err = fm.Close()
+	t.NoError(err, "close previously created file")
+
+	// delete the file
+	err = fm.Delete()
+	t.NoError(err, "delete the managed file")
+
+	// created file should no longer exist
+	exists, err = fm.Exists()
+	t.NoError(err, "created file shouldn't exist")
+	t.False(exists, "created file shouldn't exist")
+}
+
+func (t *FileManagerTestSuite) Test_CreateInvalidFilePath() {
+	fm := NewManagedFile()
+	defer fm.Close()
+
+	err := fm.Init(
+		filepath.Join(t.tmpDir, "does", "not", "exist"),
+		"",
+		"",
+		0600,
+	)
+	t.NoError(err, "fm.Init()'d")
+
+	// create should fail because path is not valid
+	err = fm.Create()
+	t.Error(err, "invalid file path")
+}
+
+func (t *FileManagerTestSuite) Test_CreateInvalidUserName() {
+	t.SkipIfRoot()
+
+	fm := NewManagedFile()
+	defer fm.Close()
+
+	err := fm.Init(
+		filepath.Join(t.tmpDir, "test_file"),
+		"root",
+		"",
+		0600,
+	)
+	t.NoError(err, "fm.Init()'d")
+
+	// create should fail because we don't have privs to chown
+	err = fm.Create()
+	t.Error(err, "no privs to chown to specified user")
+}
+
+func (t *FileManagerTestSuite) Test_CreateInvalidUid() {
+	fm := NewManagedFile()
+	defer fm.Close()
+
+	err := fm.Init(
+		filepath.Join(t.tmpDir, "test_file"),
+		"root",
+		"",
+		0600,
+	)
+	t.NoError(err, "fm.Init()'d")
+
+	// create should fail because uid is not parseable
+	fm.user.Uid = "not-a-number"
+	err = fm.Create()
+	t.Error(err, "can't chown to a non-parseable uid")
+}
+
+func (t *FileManagerTestSuite) Test_CreateInvalidGroupName() {
+	t.SkipIfRoot()
+
+	fm := NewManagedFile()
+	defer fm.Close()
+
+	err := fm.Init(
+		filepath.Join(t.tmpDir, "test_file"),
+		"",
+		"root",
+		0600,
+	)
+	t.NoError(err, "fm.Init()'d")
+
+	// create should fail because we don't have privs to chown
+	err = fm.Create()
+	t.Error(err, "invalid group")
+}
+
+func (t *FileManagerTestSuite) Test_CreateInvalidGid() {
+	fm := NewManagedFile()
+	defer fm.Close()
+
+	err := fm.Init(
+		filepath.Join(t.tmpDir, "test_file"),
+		"",
+		"root",
+		0600,
+	)
+	t.NoError(err, "fm.Init()'d")
+
+	// create should fail because gid is not parseable
+	fm.group.Gid = "not-a-number"
+	err = fm.Create()
+	t.Error(err, "can't chown to a non-parseable gid")
+}
+
+func (t *FileManagerTestSuite) Test_InitNoAccessPerms() {
+	fm := NewManagedFile()
+	defer fm.Close()
+
+	// create should fail as perms will deny file access
+	err := fm.Init(
+		filepath.Join(t.tmpDir, "test_file"),
+		"",
+		"",
+		0,
+	)
+	t.Error(err, "no access perms specified")
+}
+
+func (t *FileManagerTestSuite) Test_CreateInvalidPerms() {
+	fm := NewManagedFile()
+	defer fm.Close()
+
+	err := fm.Init(
+		filepath.Join(t.tmpDir, "test_file"),
+		"",
+		"",
+		0600,
+	)
+	t.NoError(err, "fm.Init()'d")
+
+	// force perms to 0 and create should fail as perms will deny file access
+	fm.perm = 0
+	err = fm.Create()
+	t.Error(err, "invalid perms specified")
+}
+
+func (t *FileManagerTestSuite) Test_UpdateDisabledAccessPerms() {
+	fm := NewManagedFile()
+	defer fm.Close()
+
+	err := fm.Init(
+		filepath.Join(t.tmpDir, "test_file"),
+		"",
+		"",
+		0600,
+	)
+	t.NoError(err, "fm.Init()'d")
+
+	// create a valid file
+	err = fm.Create()
+	t.NoError(err, "created with valid perms")
+
+	// attempt to update perms to remove access
+	err = fm.SetPerm(0)
+	t.Error(err, "no access perms specified")
+}
+
+func (t *FileManagerTestSuite) Test_CreateSpecialPerms() {
+	t.SkipIfRoot()
+
+	fm := NewManagedFile()
+	defer fm.Close()
+
+	err := fm.Init(
+		filepath.Join(t.tmpDir, "test_file"),
+		"",
+		"",
+		0600|fs.ModeSetgid,
+	)
+	t.NoError(err, "fm.Init()'d")
+
+	// attempt to create a file with special perms beyond access
+	err = fm.Create()
+	t.NoError(err, "create with special perms")
+}
+
+func (t *FileManagerTestSuite) Test_UpdateSpecialPerms() {
+	fm := NewManagedFile()
+	defer fm.Close()
+
+	err := fm.Init(
+		filepath.Join(t.tmpDir, "test_file"),
+		"",
+		"",
+		0600,
+	)
+	t.NoError(err, "fm.Init()'d")
+
+	// create a valid file
+	err = fm.Create()
+	t.NoError(err, "created with valid perms")
+
+	// attempt to update with special perms beyond access
+	err = fm.SetPerm(fm.perm | fs.ModeSetgid)
+	t.NoError(err, "update with special perms")
+}
+
+func (t *FileManagerTestSuite) Test_SetPath() {
+	fm := NewManagedFile()
+	defer fm.Close()
+
+	patha := filepath.Join(t.tmpDir, "test_file_a")
+	pathb := filepath.Join(t.tmpDir, "test_file_b")
+	pathc := filepath.Join(t.tmpDir, "test_file_c")
+
+	err := fm.Init(
+		patha,
+		"",
+		"",
+		0600,
+	)
+	t.NoError(err, "init first path")
+
+	// first path shouldn't exist yet
+	exists, err := fm.Exists()
+	t.NoError(err, "first path Exists() shouldn't fail")
+	t.False(exists, "first path shouldn't exist")
+	t.Empty(fm.file, "first path not created/opened")
+
+	// change the second path before creating the file
+	err = fm.SetPath(pathb)
+	t.NoError(err, "switch to second path")
+
+	// second path shouldn't exist yet
+	exists, err = fm.Exists()
+	t.NoError(err, "second path Exists() shouldn't fail")
+	t.False(exists, "second path shouldn't exist")
+	t.Empty(fm.file, "second path not created/opened")
+
+	// create the second file
+	err = fm.Create()
+	t.NoError(err, "create second path")
+
+	// second path should now exist
+	exists, err = fm.Exists()
+	t.NoError(err, "second path Exists() shouldn't fail")
+	t.True(exists, "second path should exist")
+	t.NotEmpty(fm.file, "second path now created/opened")
+	t.Equal(
+		pathb,
+		fm.file.Name(),
+		"opened file name should match second file path",
+	)
+
+	// change to the third path
+	err = fm.SetPath(pathc)
+	t.NoError(err, "switch to third path")
+
+	// third path shouldn't exist yet
+	exists, err = fm.Exists()
+	t.NoError(err, "third path Exists() shouldn't fail")
+	t.False(exists, "third path shouldn't exist")
+	t.Empty(fm.file, "third path not created/opened")
+
+	// switch back to second path which should exist
+	err = fm.SetPath(pathb)
+	t.NoError(err, "switch back to second path")
+
+	// confirm second path exists
+	exists, err = fm.Exists()
+	t.NoError(err, "second path Exists() shouldn't fail")
+	t.True(exists, "second path should exist")
+	t.Empty(fm.file, "second path yet opened")
+}
+
+func (t *FileManagerTestSuite) Test_ReadWriteBackup() {
+	path := filepath.Join(t.tmpDir, "test_file")
+	user := ""
+	group := ""
+	perm := os.FileMode(0600)
+	first_body := []byte("the first content body")
+	second_body := []byte("the second content body is longer")
+	short_body := []byte("short body")
+
+	// create a file manager for the target path
+	orig := NewManagedFile()
+	defer orig.Close()
+
+	err := orig.Init(
+		path,
+		user,
+		group,
+		perm,
+	)
+	t.NoError(err, "orig.Init()d")
+
+	// path shouldn't exist yet
+	exists, err := orig.Exists()
+	t.NoError(err, "orig.Exists() shouldn't fail")
+	t.False(exists, "original path shouldn't exist")
+	t.Empty(orig.file, "original path not created/opened")
+
+	// create a file manager for the backup path
+	bkupPath := orig.backupFileName()
+	bkup := NewManagedFile()
+	defer bkup.Close()
+
+	err = bkup.Init(
+		bkupPath,
+		user,
+		group,
+		perm,
+	)
+	t.NoError(err, "bkup.Init()d")
+
+	// bkupPath shouldn't exist yet
+	exists, err = bkup.Exists()
+	t.NoError(err, "bkup.Exists() shouldn't fail")
+	t.False(exists, "backup path shouldn't exist")
+
+	// backing up a file that doesn't exist yet should fail
+	err = orig.Backup()
+	t.Error(err, "original path doesn't exist yet")
+
+	// create the file
+	err = orig.Create()
+	t.NoError(err, "orig.Create()")
+
+	// original path should exist now
+	exists, err = orig.Exists()
+	t.NoError(err, "orig.Exists() shouldn't fail")
+	t.True(exists, "original path should exist")
+	t.NotEmpty(orig.file, "original path opened")
+
+	// backup should now succeed
+	err = orig.Backup()
+	t.NoError(err, "backup of original path should succeed")
+
+	// backup path should exist now
+	exists, err = bkup.Exists()
+	t.NoError(err, "bkup.Exists() shouldn't fail")
+	t.True(exists, "backup path should exist")
+
+	// write content to path
+	err = orig.Update([]byte(first_body))
+	t.NoError(err, "orig.Update(first_body) should succeed")
+
+	// ensure path contents are match what was written
+	content, err := orig.Read()
+	t.NoError(err, "orig.Read() should succeed")
+	t.Equal(first_body, content, "original content should match what was just written")
+
+	// bkupPath should still exist
+	exists, err = bkup.Exists()
+	t.NoError(err, "bkup.Exists() shouldn't fail")
+	t.True(exists, "bkupPath should exist")
+
+	// open backup file
+	err = bkup.Create()
+	t.NoError(err, "should be able to open backup file")
+	t.NotEmpty(bkup.file, "backup file should be open")
+
+	// backup should be empty
+	content, err = bkup.Read()
+	t.NoError(err, "bkup.Read() should succeed")
+	t.Empty(content, "backup content should empty")
+
+	// close the backup
+	err = bkup.Close()
+	t.NoError(err, "bkup.Close() should succeed")
+
+	// backup with initial non-empty content should succeed
+	err = orig.Backup()
+	t.NoError(err, "backup of initial non-empty content should succeed")
+
+	// open backup file
+	err = bkup.Create()
+	t.NoError(err, "should be able to open backup file")
+	t.NotEmpty(bkup.file, "backup file should be open")
+
+	// backup contents should match initial non-empty content of original file
+	content, err = bkup.Read()
+	t.NoError(err, "bkup.Read() should succeed")
+	t.Equal(first_body, content, "backup content should match original")
+
+	// close the backup
+	err = bkup.Close()
+	t.NoError(err, "bkup.Close() should succeed")
+
+	// update original with longer content
+	err = orig.Update([]byte(second_body))
+	t.NoError(err, "orig.Update(second_body) should succeed")
+
+	// original content should have been updated
+	content, err = orig.Read()
+	t.NoError(err, "orig.Read() should succeed")
+	t.Equal(second_body, content, "read content should match what was just written")
+
+	// open backup file
+	err = bkup.Create()
+	t.NoError(err, "should be able to open backup file")
+	t.NotEmpty(bkup.file, "backup file should be open")
+
+	// backup content should not have changed
+	content, err = bkup.Read()
+	t.NoError(err, "bkup.Read() should succeed")
+	t.Equal(first_body, content, "backup content should match initial update")
+
+	// close the backup
+	err = bkup.Close()
+	t.NoError(err, "bkup.Close() should succeed")
+
+	// update original with shorter content
+	err = orig.Update([]byte(short_body))
+	t.NoError(err, "orig.Update(short_body) should succeed")
+
+	// original content should have been updated
+	content, err = orig.Read()
+	t.NoError(err, "orig.Read() should succeed")
+	t.Equal(short_body, content, "original content should match what was just written")
+
+	// backup with of short content should succeed
+	err = orig.Backup()
+	t.NoError(err, "backup of short content should succeed")
+
+	// open backup file
+	err = bkup.Create()
+	t.NoError(err, "should be able to open backup file")
+	t.NotEmpty(bkup.file, "backup file should be open")
+
+	// backup content should not have changed
+	content, err = bkup.Read()
+	t.NoError(err, "bkup.Read() should succeed")
+	t.Equal(short_body, content, "backup content should match short content")
+
+	// close the backup
+	err = bkup.Close()
+	t.NoError(err, "bkup.Close() should succeed")
+}
+
+func (t *FileManagerTestSuite) Test_LockUnlock() {
+	fm := NewManagedFile()
+	defer fm.Close()
+
+	err := fm.Init(
+		filepath.Join(t.tmpDir, "test_file"),
+		"",
+		"",
+		0600,
+	)
+	t.NoError(err, "fm.Init()'d")
+
+	// create the file
+	err = fm.Create()
+	t.NoError(err, "create the managed file")
+
+	// file should be created as unlocked
+	t.False(fm.IsLocked(), "managed file should be unlocked initially")
+
+	// lock the file
+	err = fm.Lock()
+	t.NoError(err, "locking managed file")
+
+	// file should be marked as locked
+	t.True(fm.IsLocked(), "managed file should now be locked")
+
+	// unlock the file
+	err = fm.Unlock()
+	t.NoError(err, "unlocking managed file")
+
+	// file should be marked as locked
+	t.False(fm.IsLocked(), "managed file should now be unlocked")
+}
+
+func (t *FileManagerTestSuite) Test_CloseLockedFile() {
+	fm := NewManagedFile()
+	defer fm.Close()
+
+	err := fm.Init(
+		filepath.Join(t.tmpDir, "test_file"),
+		"",
+		"",
+		0600,
+	)
+	t.NoError(err, "fm.Init()'d")
+
+	// create the file
+	err = fm.Create()
+	t.NoError(err, "create the managed file")
+
+	// file should be created as unlocked
+	t.False(fm.IsLocked(), "managed file should be unlocked initially")
+
+	// lock the file
+	err = fm.Lock()
+	t.NoError(err, "locking managed file")
+
+	// file should be marked as locked
+	t.True(fm.IsLocked(), "managed file should now be locked")
+
+	// close the file
+	err = fm.Close()
+	t.NoError(err, "closing locked managed file")
+
+	// file should be marked as locked
+	t.False(fm.IsLocked(), "managed file should now be unlocked")
+}
+
+func (t *FileManagerTestSuite) Test_DeleteLockedFile() {
+	fm := NewManagedFile()
+	defer fm.Close()
+
+	err := fm.Init(
+		filepath.Join(t.tmpDir, "test_file"),
+		"",
+		"",
+		0600,
+	)
+	t.NoError(err, "fm.Init()'d")
+
+	// create the file
+	err = fm.Create()
+	t.NoError(err, "create the managed file")
+
+	// file should be created as unlocked
+	t.False(fm.IsLocked(), "managed file should be unlocked initially")
+
+	// lock the file
+	err = fm.Lock()
+	t.NoError(err, "locking managed file")
+
+	// file should be marked as locked
+	t.True(fm.IsLocked(), "managed file should now be locked")
+
+	// unlock the file
+	err = fm.Delete()
+	t.NoError(err, "deleting locked managed file")
+
+	// file should be marked as locked
+	t.False(fm.IsLocked(), "managed file should now be unlocked")
+}
+
+func TestFileManager(t *testing.T) {
+	suite.Run(t, new(FileManagerTestSuite))
+}


### PR DESCRIPTION
The ManagedFile type implements the new FileManager interface, and provides support for CRUD operations as well as backup and advisory locking.

Initial updates to the config file handling to leverage ManagedFile to access the config file.

Also added support for display test coverage details after running the tests in the test-verbose make target.