### PR TITLE
Design Update Related Enhancements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GO_COVERAGE_PROFILE=/tmp/.coverage.telemetry.out
+export GO_COVERAGE_PROFILE = /tmp/.coverage.telemetry.out
 
 .DEFAULT_GOAL := build
 

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,15 @@
-ifeq ($(MAKELEVEL),0)
+GO_COVERAGE_PROFILE=/tmp/.coverage.telemetry.out
 
 .DEFAULT_GOAL := build
 
+ifeq ($(MAKELEVEL),0)
+
 SUBDIRS = \
-  . \
   cmd/authenticator \
   cmd/clientds \
   cmd/generator \
-  examples/app
+  examples/app \
+  .
 
 TARGETS = fmt vet build build-only clean test test-clean test-verbose tidy
 
@@ -15,6 +17,10 @@ TARGETS = fmt vet build build-only clean test test-clean test-verbose tidy
 
 $(TARGETS):
 	$(foreach subdir, $(SUBDIRS), $(MAKE) -C $(subdir) $@ || exit 1;)
+
+test-coverage: test
+	go tool cover --func=$(GO_COVERAGE_PROFILE)
+
 else
 include Makefile.golang
 endif

--- a/Makefile.golang
+++ b/Makefile.golang
@@ -1,8 +1,4 @@
-COVERAGE_PROFILE=/tmp/.coverage.telemetry.out
-
-.DEFAULT_GOAL := build
-
-.PHONY: fmt vet build build-only clean test-clean test-verbose
+.PHONY: fmt vet build build-only clean test-clean test-verbose test-coverage
 
 fmt:
 	go fmt ./...
@@ -22,11 +18,11 @@ test-clean:
 	go clean -testcache
 
 test: test-clean build
-	go test -cover ./...
+	go test -cover -coverprofile=$(GO_COVERAGE_PROFILE) ./...
 
 test-verbose: test-clean build
-	go test -v -cover -coverprofile=$(COVERAGE_PROFILE) ./... && \
-	go tool cover --func=$(COVERAGE_PROFILE)
+	go test -v -cover -coverprofile=$(GO_COVERAGE_PROFILE) ./... && \
+	go tool cover --func=$(GO_COVERAGE_PROFILE)
 
 tidy:
 	go mod tidy

--- a/cmd/authenticator/main.go
+++ b/cmd/authenticator/main.go
@@ -115,7 +115,7 @@ func main() {
 }
 
 func init() {
-	flag.StringVar(&opts.config, "config", client.CONFIG_PATH, "Path to config file to read")
+	flag.StringVar(&opts.config, "config", config.DEF_CFG_PATH, "Path to config file to read")
 	flag.BoolVar(&opts.debug, "debug", false, "Whether to enable debug level logging.")
 	flag.BoolVar(&opts.dryrun, "dryrun", false, "Process provided JSON files but do add them to the telemetry staging area.")
 	flag.BoolVar(&opts.noregister, "noregister", false, "Whether to skip registering the telemetry client if it is needed.")

--- a/cmd/clientds/main.go
+++ b/cmd/clientds/main.go
@@ -142,7 +142,7 @@ func main() {
 
 func init() {
 	flag.BoolVar(&opts.debug, "debug", false, "Enable debug level logging")
-	flag.StringVar(&opts.config, "config", client.CONFIG_PATH, "Path to config file to read")
+	flag.StringVar(&opts.config, "config", config.DEF_CFG_PATH, "Path to config file to read")
 	flag.BoolVar(&opts.items, "items", false, "Report details on telemetry data items datastore")
 	flag.BoolVar(&opts.bundles, "bundles", false, "Report details on telemetry bundles datastore")
 	flag.BoolVar(&opts.reports, "reports", false, "Report details on telemetry reports datastore")

--- a/cmd/generator/main.go
+++ b/cmd/generator/main.go
@@ -166,7 +166,7 @@ func main() {
 }
 
 func init() {
-	flag.StringVar(&opts.config, "config", client.CONFIG_PATH, "Path to config file to read")
+	flag.StringVar(&opts.config, "config", config.DEF_CFG_PATH, "Path to config file to read")
 	flag.BoolVar(&opts.debug, "debug", false, "Whether to enable debug level logging.")
 	flag.BoolVar(&opts.dryrun, "dryrun", false, "Process provided JSON files but do add them to the telemetry staging area.")
 	flag.BoolVar(&opts.noregister, "noregister", false, "Whether to skip registering the telemetry client if it is needed.")

--- a/doc/api/requests/report.md
+++ b/doc/api/requests/report.md
@@ -7,7 +7,7 @@ Type: ***POST***
 | Name | Type | Description | Example |
 | ---- | ---- | ----------- | ------- |
 | [Authorization](../headers/authorization.md) | header | A `Bearer` schema authorization | `Authorization: Bearer <JWT>`<br>Where \<JWT\> specifies the [JWT](https://jwt.io/) |
-| [X-Telemetry-Client-Id](../headers/telemetry-client-id.md) | header | The clientId of the telemetry client<br>submitting the report | `X-Telemetry-Client-Id: 1234567890` |
+| [X-Telemetry-Registration-Id](../headers/telemetry-registration-id.md) | header | The registrationId of the telemetry client<br>submitting the report | `X-Telemetry-Registration-Id: 1234567890` |
 | body | object | A [Telemetry Report](../structs/telemetryreport.md) containing<br>one or more [Telemetry Bundles](../structs/telemetrybundles.md) | See [Telemetry Report](../structs/telemetryreport.md) for more details. |
 
 ## Responses

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/mattn/go-sqlite3 v1.14.22
 	github.com/stretchr/testify v1.9.0
-	github.com/xyproto/randomstring v1.0.5
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,6 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
-github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/pkg/client/registration_management.go
+++ b/pkg/client/registration_management.go
@@ -2,33 +2,62 @@ package client
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
-	"io/fs"
 	"log/slog"
 	"os"
+	"path/filepath"
 
+	"github.com/SUSE/telemetry/pkg/config"
 	"github.com/SUSE/telemetry/pkg/types"
+	"github.com/SUSE/telemetry/pkg/utils"
 	"github.com/google/uuid"
 )
 
 const (
-	REGISTRATION_PATH = CONFIG_DIR + "/registration"
+	REGISTRATION_NAME = `registration`
+	REGISTRATION_PERM = 0600
 )
 
 type TelemetryClientRegistration struct {
 	types.ClientRegistration
-	path     string
+	config   *config.Config
+	regFile  utils.FileManager
 	valid    bool
 	no_retry bool
 }
 
-func NewTelemetryClientRegistration() *TelemetryClientRegistration {
-	return &TelemetryClientRegistration{
-		path:     REGISTRATION_PATH,
+func NewTelemetryClientRegistration(cfg *config.Config) (*TelemetryClientRegistration, error) {
+	regPath := filepath.Join(cfg.ConfigDir(), REGISTRATION_NAME)
+	r := &TelemetryClientRegistration{
+		config:   cfg,
 		valid:    false,
 		no_retry: false,
 	}
+
+	// create a managed file to manage the registration file based upon
+	// the location, ownership and permissions of the config file with
+	// backups disabled.
+	fm := utils.NewManagedFile()
+	err := fm.Init(
+		regPath,
+		r.config.ConfigUser(),
+		r.config.ConfigGroup(),
+		REGISTRATION_PERM,
+	)
+	fm.DisableBackups()
+
+	if err != nil {
+		slog.Debug(
+			"failed to setup registration file manager",
+			slog.String("path", regPath),
+			slog.String("err", err.Error()),
+		)
+		return nil, fmt.Errorf("failed to setup registration file manager: %w", err)
+	}
+
+	r.regFile = fm
+
+	return r, nil
 }
 
 func (r *TelemetryClientRegistration) RetriesEnabled() bool {
@@ -44,26 +73,47 @@ func (r *TelemetryClientRegistration) Valid() bool {
 }
 
 func (r *TelemetryClientRegistration) Path() string {
-	return r.path
-}
-
-// for testing purposes
-func (r *TelemetryClientRegistration) SetPath(path string) {
-	r.path = path
+	return r.regFile.Path()
 }
 
 func (r *TelemetryClientRegistration) Accessible() bool {
-	if _, err := os.Open(r.path); err != nil {
+	if _, err := os.Open(r.Path()); err != nil {
 		return false
 	}
 	return true
 }
 
-func (r *TelemetryClientRegistration) Generate() {
-	r.ClientId = uuid.New().String()
+func (r *TelemetryClientRegistration) Generate() (err error) {
+	// if no client id is configured, generate a new client id and
+	// attempt to save it
+	if r.config.ClientId == "" {
+		r.config.ClientId = uuid.New().String()
+		err = r.config.Save()
+		if err != nil {
+			slog.Debug(
+				"failed to save updated config after generating a new client id",
+				slog.String("config", r.config.ConfigPath()),
+				slog.String("err", err.Error()),
+			)
+			return fmt.Errorf("failed to save config after generating client id: %w", err)
+		}
+	}
+
+	r.ClientId = r.config.ClientId
 	r.SystemUUID = getSystemUUID()
 	r.Timestamp = types.Now().String()
 	r.valid = true
+
+	// attempt to save the newly generated registration
+	err = r.Save()
+	if err != nil {
+		// we failed to save the registration the mark it as invalid
+		r.valid = false
+
+		return
+	}
+
+	return
 }
 
 func (r *TelemetryClientRegistration) Registration() types.ClientRegistration {
@@ -73,7 +123,7 @@ func (r *TelemetryClientRegistration) Registration() types.ClientRegistration {
 func (r *TelemetryClientRegistration) String() string {
 	return fmt.Sprintf(
 		"<p:%q, v:%v, r:%q>",
-		r.path,
+		r.Path(),
 		r.valid,
 		r.ClientRegistration.String(),
 	)
@@ -84,6 +134,16 @@ func (r *TelemetryClientRegistration) Save() (err error) {
 	if !r.valid {
 		return fmt.Errorf("client registration not valid; cannot save")
 	}
+
+	err = r.regFile.Create()
+	if err != nil {
+		slog.Debug(
+			"failed to create/open registration",
+			slog.String("path", r.Path()),
+			slog.String("err", err.Error()),
+		)
+	}
+	defer r.regFile.Close()
 
 	// marshal the registration public fields as JSON
 	bytes, err := json.Marshal(r)
@@ -97,10 +157,10 @@ func (r *TelemetryClientRegistration) Save() (err error) {
 	}
 
 	// save the JSON encoded registration fields
-	err = os.WriteFile(r.path, bytes, 0600)
+	err = r.regFile.Update(bytes)
 	if err != nil {
 		slog.Error(
-			"failed to write client registration file",
+			"failed to save client registration file",
 			slog.String("reg", r.String()),
 			slog.String("err", err.Error()),
 		)
@@ -116,30 +176,41 @@ func (r *TelemetryClientRegistration) Save() (err error) {
 
 func (r *TelemetryClientRegistration) Load() (err error) {
 	// check that the specified path exists, failing appropriately
-	// if there are any issues os.Stat()ing the file.
-	_, err = os.Stat(r.path)
+	exists, err := r.regFile.Exists()
 	if err != nil {
-		var msg string
-		if errors.Is(err, fs.ErrNotExist) {
-			msg = "client registration file not found"
-		} else {
-			msg = "unable to os.Stat() client registration file"
-		}
-		slog.Error(
-			msg,
-			slog.String("regPath", r.path),
+		slog.Debug(
+			"unable to check for client registration file",
+			slog.String("path", r.Path()),
 			slog.String("err", err.Error()),
+		)
+	}
+	if !exists {
+		slog.Error(
+			"client registration file not found",
+			slog.String("path", r.Path()),
 		)
 		return
 	}
 
-	// retrieve the contents of the specified client registration file,
-	// failing if unable to do so.
-	bytes, err := os.ReadFile(r.path)
+	// open the registration file
+	err = r.regFile.Open(
+		false, // no need to create, should already exist
+	)
+	if err != nil {
+		slog.Error(
+			"failed to open client registration",
+			slog.String("path", r.Path()),
+		)
+		return
+	}
+	defer r.regFile.Close()
+
+	// retrieve the contents of the specified client registration file
+	bytes, err := r.regFile.Read()
 	if err != nil {
 		slog.Error(
 			"failed to read client registration file",
-			slog.String("regPath", r.path),
+			slog.String("path", r.Path()),
 			slog.String("err", err.Error()),
 		)
 		return
@@ -151,7 +222,7 @@ func (r *TelemetryClientRegistration) Load() (err error) {
 	if err != nil {
 		slog.Error(
 			"failed to json.Unmarshal() client registration file contents",
-			slog.String("regPath", r.path),
+			slog.String("path", r.Path()),
 			slog.String("contents", string(bytes)),
 			slog.String("err", err.Error()),
 		)
@@ -160,8 +231,10 @@ func (r *TelemetryClientRegistration) Load() (err error) {
 
 	slog.Debug(
 		"client registration loaded",
+		slog.String("path", r.Path()),
 		slog.String("reg", r.String()),
 	)
+
 	return
 }
 
@@ -169,30 +242,21 @@ func (r *TelemetryClientRegistration) Remove() (err error) {
 	// mark in-memory version as invalid
 	r.valid = false
 
-	// check if registration file exists
-	_, err = os.Stat(r.path)
-	if err != nil {
-		if !errors.Is(err, fs.ErrNotExist) {
-			// nothing to do, and not a failure, if registration file doesn't exist
-			err = nil
-		} else {
-			slog.Error(
-				"unable to os.Stat() client registration file",
-				slog.String("regPath", r.path),
-				slog.String("err", err.Error()),
-			)
-		}
+	// nothing to do if file doesn't exist
+	exists, _ := r.regFile.Exists()
+	if !exists {
 		return
 	}
 
-	// remove the registration client, reporting any errors that occurr
-	err = os.Remove(r.path)
+	// delete the registration file
+	err = r.regFile.Delete()
 	if err != nil {
 		slog.Error(
-			"failed to os.Remove() client registration file",
-			slog.String("regPath", r.path),
+			"failed to delete client registration",
+			slog.String("path", r.Path()),
 			slog.String("err", err.Error()),
 		)
+		return fmt.Errorf("failed to os.Remove(%q): %w", r.Path(), err)
 	}
 
 	return

--- a/pkg/client/systemuuid.go
+++ b/pkg/client/systemuuid.go
@@ -3,6 +3,8 @@ package client
 import (
 	"log/slog"
 	"os"
+
+	"github.com/SUSE/telemetry/pkg/utils"
 )
 
 const (
@@ -16,7 +18,7 @@ func getSystemUUID() string {
 	sysuuidPath := LINUX_SYSTEM_UUID_PATH
 
 	// if identified system UUID path doesn't exist, return empty string
-	if !checkFileExists(sysuuidPath) {
+	if !utils.CheckPathExists(sysuuidPath) {
 		slog.Debug(
 			"Unable to locate the Linux hardware UUID",
 			slog.String("path", sysuuidPath),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,7 +2,9 @@ package config
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"path/filepath"
 	"slices"
@@ -13,56 +15,49 @@ import (
 	"github.com/SUSE/telemetry/pkg/utils"
 )
 
-type Config struct {
-	TelemetryBaseURL string             `yaml:"telemetry_base_url"`
-	Enabled          bool               `yaml:"enabled"`
-	ClientId         string             `yaml:"client_id"`
-	CustomerId       string             `yaml:"customer_id"`
-	Tags             []string           `yaml:"tags"`
-	DataStores       DBConfig           `yaml:"datastores"`
-	ClassOptions     ClassOptionsConfig `yaml:"classOptions"`
-	Logging          LogConfig          `yaml:"logging"`
-	Extras           any                `yaml:"extras,omitempty"`
-	cfgPath          string
-}
+const (
+	// config file defaults
+	DEF_CFG_DIR   = `/etc/susetelemetry`
+	DEF_CFG_FILE  = `telemetry.yaml`
+	DEF_CFG_PATH  = DEF_CFG_DIR + `/` + DEF_CFG_FILE
+	DEF_CFG_USER  = `susetelm`
+	DEF_CFG_GROUP = `susetelm`
+	DEF_CFG_PERM  = 0640
 
-// Defaults
-var DefaultDBCfg = DBConfig{
-	Driver: "sqlite3",
-	Params: "/tmp/telemetry/client/telemetry.db",
-}
+	// config defaults
+	DEF_CFG_ENABLED     = false
+	DEF_CFG_BASE_URL    = `https://scc.suse.com/telemetry/`
+	DEF_CFG_CLIENT_ID   = ``
+	DEF_CFG_CUSTOMER_ID = ``
 
-var DefaultLogging = LogConfig{
-	Level:    "info",
-	Location: "stderr",
-	Style:    "text",
-}
+	// data store defaults
+	DEF_CFG_DB_DRIVER = `sqlite3`
+	DEF_CFG_DB_DIR    = `/var/lib/` + DEF_CFG_USER + `/client`
+	DEF_CFG_DB_FILE   = `telemetry.db`
+	DEF_CFG_DB_PATH   = DEF_CFG_DB_DIR + `/` + DEF_CFG_DB_FILE
 
-var DefaultClassOptions = ClassOptionsConfig{
-	OptOut: true,
-	OptIn:  false,
-	Allow:  []types.TelemetryType{},
-	Deny:   []types.TelemetryType{},
-}
+	// logging defaults
+	DEF_CFG_LOG_LEVEL    = `info`
+	DEF_CFG_LOG_LOCATION = `stderr`
+	DEF_CFG_LOG_STYLE    = `text`
 
-var DefaultCfg = Config{
-	//TelemetryBaseURL: "https://scc.suse.com/telemetry/",
-	TelemetryBaseURL: "http://localhost:9999/telemetry",
-	Enabled:          false,
-	ClientId:         "",
-	CustomerId:       "0",
-	Tags:             []string{},
-	DataStores:       DefaultDBCfg,
-	Logging:          DefaultLogging,
-	ClassOptions:     DefaultClassOptions,
-}
+	// class defaults
+	DEF_CFG_OPT_OUT = true
+	DEF_CFG_OPT_IN  = false
+)
 
-// Datastore config for staging the data
+// datastore config for staging provided telemetry data
 type DBConfig struct {
 	Driver string `yaml:"driver"`
 	Params string `yaml:"params"`
 }
 
+func (dc *DBConfig) String() string {
+	str, _ := json.Marshal(dc)
+	return string(str)
+}
+
+// logging config
 type LogConfig struct {
 	Level    string `yaml:"level" json:"level"`
 	Location string `yaml:"location" json:"location"`
@@ -74,6 +69,7 @@ func (lc *LogConfig) String() string {
 	return string(str)
 }
 
+// telemetry class options configuration
 type ClassOptionsConfig struct {
 	OptOut bool                  `yaml:"opt_out" json:"opt_out"`
 	OptIn  bool                  `yaml:"opt_in" json:"opt_in"`
@@ -81,63 +77,259 @@ type ClassOptionsConfig struct {
 	Deny   []types.TelemetryType `yaml:"deny" json:"deny"`
 }
 
+func (cc *ClassOptionsConfig) String() string {
+	str, _ := json.Marshal(cc)
+	return string(str)
+}
+
+type Config struct {
+	TelemetryBaseURL string             `yaml:"telemetry_base_url"`
+	Enabled          bool               `yaml:"enabled"`
+	ClientId         string             `yaml:"client_id"`
+	CustomerId       string             `yaml:"customer_id"`
+	Tags             []string           `yaml:"tags"`
+	DataStores       DBConfig           `yaml:"datastores"`
+	ClassOptions     ClassOptionsConfig `yaml:"class_options"`
+	Logging          LogConfig          `yaml:"logging"`
+	Extras           any                `yaml:"extras,omitempty"`
+
+	cfgPath string
+	cfgDir  string
+	cfgFile utils.FileManager
+}
+
+func (c *Config) ConfigDir() string {
+	return c.cfgDir
+}
+
+func (c *Config) ConfigPath() string {
+	return c.cfgPath
+}
+
+func (c *Config) ConfigName() string {
+	return filepath.Base(c.cfgPath)
+}
+
+func (c *Config) ConfigUser() string {
+	return c.cfgFile.User()
+}
+
+func (c *Config) ConfigGroup() string {
+	return c.cfgFile.Group()
+}
+
+func NewDefaultConfig() *Config {
+
+	return &Config{
+		TelemetryBaseURL: DEF_CFG_BASE_URL,
+		Enabled:          DEF_CFG_ENABLED,
+		ClientId:         DEF_CFG_CLIENT_ID,
+		CustomerId:       DEF_CFG_CUSTOMER_ID,
+		Tags:             []string{},
+
+		DataStores: DBConfig{
+			Driver: DEF_CFG_DB_DRIVER,
+			Params: DEF_CFG_DB_PATH,
+		},
+
+		Logging: LogConfig{
+			Level:    DEF_CFG_LOG_LEVEL,
+			Location: DEF_CFG_LOG_LOCATION,
+			Style:    DEF_CFG_LOG_STYLE,
+		},
+
+		ClassOptions: ClassOptionsConfig{
+			OptOut: DEF_CFG_OPT_OUT,
+			OptIn:  DEF_CFG_OPT_IN,
+			Allow:  []types.TelemetryType{},
+			Deny:   []types.TelemetryType{},
+		},
+
+		cfgPath: DEF_CFG_PATH,
+	}
+}
+
+func (cfg *Config) create_with_defaults() (err error) {
+	// cfg should have a valid cfgPath, cfgDir and cfgFile
+	if cfg.cfgPath == "" || cfg.cfgDir == "" || cfg.cfgFile == nil {
+		return fmt.Errorf("config not initialised correctly")
+	}
+
+	// attempt to setup the user, group and perms for the config file
+	slog.Warn(
+		"config file doesn't exist, using builtin defaults",
+		slog.String("path", cfg.cfgPath),
+		slog.String("config", cfg.String()),
+	)
+
+	// setup default user
+	if err = cfg.cfgFile.SetUser(DEF_CFG_USER); err != nil {
+		slog.Debug(
+			"failed to set user for config file",
+			slog.String("path", cfg.cfgPath),
+			slog.String("user", DEF_CFG_USER),
+			slog.String("err", err.Error()),
+		)
+		return err
+	}
+
+	// setup default group
+	if err = cfg.cfgFile.SetUser(DEF_CFG_USER); err != nil {
+		slog.Debug(
+			"failed to set user for config file",
+			slog.String("path", cfg.cfgPath),
+			slog.String("user", DEF_CFG_USER),
+			slog.String("err", err.Error()),
+		)
+		return err
+	}
+
+	// setup default perms
+	if err = cfg.cfgFile.SetPerm(DEF_CFG_PERM); err != nil {
+		slog.Debug(
+			"failed to set permissions for config file",
+			slog.String("path", cfg.cfgPath),
+			slog.String("perm", fs.FileMode(DEF_CFG_PERM).String()),
+			slog.String("err", err.Error()),
+		)
+		return err
+	}
+
+	// attempt to create the file with the default config settings
+	if err = cfg.cfgFile.Create(); err != nil {
+		slog.Debug(
+			"failed to create config file",
+			slog.String("path", cfg.cfgPath),
+			slog.String("err", err.Error()),
+		)
+		return err
+	}
+
+	// attempt to init config file with default config settings
+	if err = cfg.Save(); err != nil {
+		slog.Debug(
+			"failed to init config file contents",
+			slog.String("path", cfg.cfgPath),
+			slog.String("err", err.Error()),
+		)
+		return err
+	}
+
+	return nil
+}
+
+func (cfg *Config) Save() (err error) {
+	content, err := yaml.Marshal(cfg)
+	if err != nil {
+		slog.Debug(
+			"failed to yaml.Marshal() config",
+			slog.String("config", cfg.String()),
+			slog.String("err", err.Error()),
+		)
+
+		return fmt.Errorf("failed to yaml.Marshal() config content: %w", err)
+	}
+
+	if err = cfg.cfgFile.Update(content); err != nil {
+		slog.Debug(
+			"failed to update config",
+			slog.String("path", cfg.cfgPath),
+			slog.String("err", err.Error()),
+		)
+
+		return fmt.Errorf("failed to write config %q: %w", cfg.cfgPath, err)
+	}
+
+	return
+}
+
+func (cfg *Config) Load() (err error) {
+	contents, err := cfg.cfgFile.Read()
+	if err != nil {
+		return fmt.Errorf("failed to read contents of config file %q: %w", cfg.cfgPath, err)
+	}
+
+	slog.Debug(
+		"Config read",
+		slog.String("contents", string(contents)),
+	)
+
+	err = yaml.Unmarshal(contents, &cfg)
+	if err != nil {
+		slog.Debug(
+			"failed to yaml.Marshal() config",
+			slog.String("config", cfg.String()),
+			slog.String("err", err.Error()),
+		)
+
+		return fmt.Errorf("failed to yaml.Unmarshal() contents of config %q: %w", cfg.cfgPath, err)
+	}
+
+	slog.Debug(
+		"Config parsed",
+		slog.String("config", cfg.String()),
+	)
+
+	return
+}
+
 func NewConfig(cfgPath string) (*Config, error) {
 
 	//Initialise with default configuration
-	cfg := &Config{}
-	*cfg = DefaultCfg
+	cfg := NewDefaultConfig()
 
-	// get absolute path of config file
-	absPath, err := filepath.Abs(cfgPath)
-	if err != nil {
-		return cfg, fmt.Errorf("unable to resolve absolute path of config file %q: %w", cfgPath, err)
-	}
-
+	// attempt to use an existing config file
 	cfgFile := utils.NewManagedFile()
-	cfgFile.Init(
-		absPath,
-		// TODO (fmccarthy): revisit the file ownership
-		"", // current user
-		"", // current user's primary group
-		0644,
-	)
-
-	exists, err := cfgFile.Exists()
-	if err != nil || !exists {
-		if err != nil {
-			slog.Debug(
-				"existence check for config file failed",
-				slog.String("cfgPath", cfgPath),
-				slog.String("err", err.Error()),
-			)
+	err := cfgFile.UseExistingFile(cfgPath)
+	if err != nil {
+		// fail if the error is something other than the config not existing
+		if !errors.Is(err, fs.ErrNotExist) {
+			return nil, fmt.Errorf("unable to access config file %q: %w", cfgPath, err)
 		}
-		slog.Warn("config file doesn't exist. Using default configuration", slog.String("cfgPath", cfgPath))
-		return cfg, nil
+
+		// if the file didn't exist ensure the managed file path is setup
+		err = cfgFile.SetPath(cfg.cfgPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to set config file path %q: %w", cfgPath, err)
+		}
 	}
 
+	// set the config path, dir and the cfgFile
+	cfg.cfgPath = cfgFile.Path()
+	cfg.cfgDir = filepath.Dir(cfg.cfgPath)
+	cfg.cfgFile = cfgFile
+
+	// if the config file doesn't exist, attempt to setup with defaults
+	if exists, _ := cfgFile.Exists(); !exists {
+		// attempt to create and initialise the configuration
+		if err = cfg.create_with_defaults(); err != nil {
+			return nil, err
+		}
+	}
+
+	// attempt to open config file, creating it necessary
 	err = cfgFile.Create()
 	if err != nil {
 		return cfg, fmt.Errorf("failed to open config file %q: %w", cfgPath, err)
 	}
 
-	// config file exists and is accessible so record it
-	cfg.cfgPath = cfgPath
-
-	contents, err := cfgFile.Read()
+	err = cfg.Load()
 	if err != nil {
-		return cfg, fmt.Errorf("failed to read contents of config file %q: %w", cfgPath, err)
-	}
-
-	slog.Debug("Config", slog.String("contents", string(contents)))
-	err = yaml.Unmarshal(contents, &cfg)
-	if err != nil {
-		return cfg, fmt.Errorf("failed to parse contents of config file %q: %w", cfgPath, err)
+		return nil, err
 	}
 
 	return cfg, nil
 }
 
+func (c *Config) String() string {
+	bytes, _ := json.Marshal(c)
+	return string(bytes)
+}
+
 func (c *Config) TelemetryClassEnabled(class types.TelemetryClass) bool {
+	if !c.Enabled {
+		return false
+	}
 
 	switch class {
 	case types.MANDATORY_TELEMETRY:
@@ -152,16 +344,20 @@ func (c *Config) TelemetryClassEnabled(class types.TelemetryClass) bool {
 }
 
 func (c *Config) TelemetryTypeEnabled(telemetry types.TelemetryType) bool {
-	// if telemetry type is in the allow list then allow it to be sent
-	if slices.Contains(c.ClassOptions.Allow, telemetry) {
-		return true
+	if !c.Enabled {
+		return false
 	}
 
-	// otherwise if telemetry type is in the deny list then deny it
+	// if telemetry type is in the deny list then deny it from being sent
 	if slices.Contains(c.ClassOptions.Deny, telemetry) {
 		return false
 	}
 
-	// otherwise allow the telemetry type
-	return true
+	// otherwise if telemetry type is in the allow list then allow it to be sent
+	if slices.Contains(c.ClassOptions.Allow, telemetry) {
+		return true
+	}
+
+	// default to allowing if allow list empty
+	return len(c.ClassOptions.Allow) == 0
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -3,42 +3,149 @@ package config
 import (
 	"fmt"
 	"os"
+	os_user "os/user"
+	"path/filepath"
 	"strings"
 	"testing"
 
-	"github.com/SUSE/telemetry/pkg/utils"
-	"github.com/stretchr/testify/assert"
+	"github.com/SUSE/telemetry/pkg/types"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
 type TestConfigTestSuite struct {
 	suite.Suite
+
+	tmpDir string
 }
 
-func (t *TestConfigTestSuite) TestConfigFileNotFound() {
-	config, err := NewConfig("nonexisting.yaml")
-	assert.NoError(t.T(), err, "error using the defaults for non existent config file")
+func (t *TestConfigTestSuite) SetupTest() {
+	tmpDir, err := os.MkdirTemp("", ".cfgTest.*")
+	t.Require().NoError(err, "os.MkdirTemp()")
+	t.Require().NotEmpty(tmpDir, "tmpDir should be setup")
 
-	assert.Equal(t.T(), DefaultCfg.TelemetryBaseURL, config.TelemetryBaseURL, "TelemetryBaseURL value is not the expected")
-	assert.Equal(t.T(), DefaultCfg.Enabled, config.Enabled, "Enabled value is not the expected")
-	assert.Equal(t.T(), DefaultCfg.ClientId, config.ClientId, "ClientId value is not the expected")
-	assert.Equal(t.T(), DefaultCfg.CustomerId, config.CustomerId, "CustomerId value is not the expected")
-	assert.Equal(t.T(), DefaultCfg.Tags, config.Tags, "Tags value is not the expected")
-	assert.Equal(t.T(), DefaultCfg.DataStores.Driver, config.DataStores.Driver, "DataStores.Driver is not the expected")
-	assert.Equal(t.T(), DefaultCfg.DataStores.Params, config.DataStores.Params, "DataStores.Params is not the expected")
-	assert.Equal(t.T(), DefaultCfg.Logging.Level, config.Logging.Level, "Logging.Level is not the expected")
-	assert.Equal(t.T(), DefaultCfg.Logging.Location, config.Logging.Location, "Logging.Location is not the expected")
-	assert.Equal(t.T(), DefaultCfg.Logging.Style, config.Logging.Style, "Logging.Style is not the expected")
-	assert.Equal(t.T(), DefaultCfg.ClassOptions.OptOut, config.ClassOptions.OptOut, "ClassOptions.OptOut is not the expected")
-	assert.Equal(t.T(), DefaultCfg.ClassOptions.OptIn, config.ClassOptions.OptIn, "ClassOptions.OptIn is not the expected")
-	assert.Equal(t.T(), DefaultCfg.ClassOptions.Allow, config.ClassOptions.Allow, "ClassOptions.Allow is not the expected")
-	assert.Equal(t.T(), DefaultCfg.ClassOptions.Deny, config.ClassOptions.Deny, "ClassOptions.Deny is not the expected")
+	t.tmpDir = tmpDir
+}
+
+func (t *TestConfigTestSuite) TearDownTest() {
+	err := os.RemoveAll(t.tmpDir)
+	t.NoError(err, "os.RemoveAll(t.tmpDir)")
+}
+
+func (t *TestConfigTestSuite) createTemp(name string) (file *os.File, err error) {
+	return os.Create(filepath.Join(t.tmpDir, name))
+}
+
+func (t *TestConfigTestSuite) TestConfigDefaults() {
+	// get current user
+	currUser, err := os_user.Current()
+	t.Require().NoError(err, "os/user.Current()")
+	t.Require().NotNil(currUser, "currUser")
+
+	// get current user's primary group
+	currGroup, err := os_user.LookupGroupId(currUser.Gid)
+	t.Require().NoError(err, "os/user.LookupGroupId(currUser.Gid)")
+	t.Require().NotNil(currGroup, "currGroup")
+
+	// create an empty file
+	cfgName := "empty.yaml"
+	emptyFile, err := t.createTemp(cfgName)
+	t.Require().NoError(err, "creating empty file")
+	cfgPath := emptyFile.Name()
+
+	err = emptyFile.Close()
+	t.Require().NoError(err, "closing created empty file")
+
+	cfg, err := NewConfig(cfgPath)
+	t.Require().NoError(err, "loading empty config")
+
+	t.Equal(t.tmpDir, cfg.ConfigDir(), "Expected config dir path")
+	t.Equal(cfgName, cfg.ConfigName(), "Expected config file name")
+	t.Equal(cfgPath, cfg.ConfigPath(), "Expected full config file path")
+	t.Equal(currUser.Username, cfg.ConfigUser(), "Expected current user")
+	t.Equal(currGroup.Name, cfg.ConfigGroup(), "Expected current user's primary group")
+
+	t.Equal(DEF_CFG_BASE_URL, cfg.TelemetryBaseURL, "TelemetryBaseURL value is not expected value")
+	t.Equal(DEF_CFG_ENABLED, cfg.Enabled, "Enabled value is not expected value")
+	t.Equal(DEF_CFG_CLIENT_ID, cfg.ClientId, "ClientId value is not expected value")
+	t.Equal(DEF_CFG_CUSTOMER_ID, cfg.CustomerId, "CustomerId value is not expected value")
+
+	t.Equal(DEF_CFG_DB_DRIVER, cfg.DataStores.Driver, "DataStores.Driver is not expected value")
+	t.Equal(DEF_CFG_DB_PATH, cfg.DataStores.Params, "DataStores.Params is not expected value")
+
+	t.Equal(DEF_CFG_LOG_LEVEL, cfg.Logging.Level, "Logging.Level is not expected value")
+	t.Equal(DEF_CFG_LOG_LOCATION, cfg.Logging.Location, "Logging.Location is not expected value")
+	t.Equal(DEF_CFG_LOG_STYLE, cfg.Logging.Style, "Logging.Style is not expected value")
+
+	t.Equal(DEF_CFG_OPT_OUT, cfg.ClassOptions.OptOut, "ClassOptions.OptOut is not expected value")
+	t.Equal(DEF_CFG_OPT_IN, cfg.ClassOptions.OptIn, "ClassOptions.OptIn is not expected value")
+	t.Empty(cfg.Tags, "Tags value is expected to be empty")
+	t.Empty(cfg.ClassOptions.Allow, "ClassOptions.Allow is expected to be empty")
+	t.Empty(cfg.ClassOptions.Deny, "ClassOptions.Deny is expected to be empty")
+
+	t.NotEmpty(cfg.String(), "string representation of config should be non-empty")
+	t.NotEmpty(cfg.ClassOptions.String(), "string representation of class options config should be non-empty")
+	t.NotEmpty(cfg.DataStores.String(), "string representation of data stores config should be non-empty")
+	t.NotEmpty(cfg.Logging.String(), "string representation of logging config should be non-empty")
+}
+
+func (t *TestConfigTestSuite) TestConfigLoadSaveUpdate() {
+	emptyFile, err := t.createTemp("config.yaml")
+	t.Require().NoError(err, "creating empty file")
+	cfgPath := emptyFile.Name()
+
+	err = emptyFile.Close()
+	t.Require().NoError(err, "closing created empty file")
+
+	defCfg, err := NewConfig(cfgPath)
+	t.Require().NoError(err, "loading empty config")
+
+	err = defCfg.Save()
+	t.Require().NoError(err, "saving default config")
+
+	loadCfg, err := NewConfig(cfgPath)
+	t.Require().NoError(err, "loading default config")
+
+	t.Equal(defCfg.String(), loadCfg.String(), "unmodified config should match default")
+
+	// toggle the enabled setting
+	loadCfg.Enabled = !loadCfg.Enabled
+
+	t.NotEqual(defCfg.String(), loadCfg.String(), "updated config shouldn't match default")
+
+	err = loadCfg.Save()
+	t.Require().NoError(err, "saving updated config")
+
+	updatedCfg, err := NewConfig(cfgPath)
+	t.Require().NoError(err, "loading updated config")
+
+	t.Equal(loadCfg.Enabled, updatedCfg.Enabled, "enabled setting should match in updated and reloaded configs")
+	t.NotEqual(defCfg.String(), updatedCfg.String(), "reloaded config shouldn't match default")
+	t.Equal(loadCfg.String(), updatedCfg.String(), "reloaded config should match updated")
+}
+
+func (t *TestConfigTestSuite) TestConfigFileDoesntExist() {
+	// skip the test if the default config user exists
+	user, err := os_user.Lookup(DEF_CFG_USER)
+	if err == nil {
+		t.T().Skipf("Skipping test as user %q exists with id %v", user.Username, user.Uid)
+	}
+
+	// skip the test if the default config user exists
+	group, err := os_user.LookupGroup(DEF_CFG_GROUP)
+	if err == nil {
+		t.T().Skipf("Skipping test as group %q exists with id %v", group.Name, group.Gid)
+	}
+
+	cfgPath := filepath.Join(t.tmpDir, "config.yaml")
+
+	_, err = NewConfig(cfgPath)
+	t.Error(err, "loading non-existent file should fail")
 }
 
 func (t *TestConfigTestSuite) TestConfigFileFound() {
-	tmpfile, err := os.CreateTemp("/tmp", "temp-cfg"+utils.GenerateRandomString(5)+".yaml")
-	require.NoError(t.T(), err)
+	tmpfile, err := t.createTemp("config.yaml")
+	t.Require().NoError(err)
 	defer os.Remove(tmpfile.Name())
 
 	url := "http://localhost:9999/telemetry"
@@ -48,7 +155,7 @@ func (t *TestConfigTestSuite) TestConfigFileFound() {
 	content := `
 telemetry_base_url: %s
 enabled: true
-customer_id: 01234
+customer_id: SOME_CUSTOMER
 tags: []
 datastores:
   driver: %s
@@ -66,20 +173,20 @@ class_options:
 
 	formattedContents := fmt.Sprintf(content, url, driver, params)
 	_, err = tmpfile.Write([]byte(formattedContents))
-	require.NoError(t.T(), err)
-	require.NoError(t.T(), tmpfile.Close())
+	t.Require().NoError(err)
+	t.Require().NoError(tmpfile.Close())
 
 	config, err := NewConfig(tmpfile.Name())
 	require.NoError(t.T(), err)
 
-	assert.Equal(t.T(), url, config.TelemetryBaseURL, "TelemetryBaseURL value is not the expected")
-	assert.Equal(t.T(), driver, config.DataStores.Driver, "DataStores.Driver is not the expected")
-	assert.Equal(t.T(), params, config.DataStores.Params, "DataStores.Params is not the expected")
+	t.Equal(url, config.TelemetryBaseURL, "TelemetryBaseURL value is not the expected")
+	t.Equal(driver, config.DataStores.Driver, "DataStores.Driver is not the expected")
+	t.Equal(params, config.DataStores.Params, "DataStores.Params is not the expected")
 }
 
 func (t *TestConfigTestSuite) TestConfigFileFoundButUnparsable() {
-	tmpfile, err := os.CreateTemp("/tmp", "temp-cfg"+utils.GenerateRandomString(5)+".yaml")
-	require.NoError(t.T(), err)
+	tmpfile, err := t.createTemp("config.yaml")
+	t.Require().NoError(err)
 	defer os.Remove(tmpfile.Name())
 
 	url := "http://localhost:9999/telemetry"
@@ -89,7 +196,7 @@ func (t *TestConfigTestSuite) TestConfigFileFoundButUnparsable() {
 	content := `
 telemetry_base_url: %s
 enabled true
-customer_id: 01234
+customer_id: SOME_CUSTOMER
 tags: []
 datastores:
   driver: %s
@@ -107,14 +214,114 @@ class_options:
 
 	formattedContents := fmt.Sprintf(content, url, driver, params)
 	_, err = tmpfile.Write([]byte(formattedContents))
-	require.NoError(t.T(), err)
-	require.NoError(t.T(), tmpfile.Close())
+	t.Require().NoError(err)
+	t.Require().NoError(tmpfile.Close())
 
 	_, err = NewConfig(tmpfile.Name())
-	if !strings.Contains(err.Error(), "failed to parse contents of config file") {
+	if !strings.Contains(err.Error(), "failed to yaml.Unmarshal() contents of config") {
 		t.T().Errorf("String '%s' does not contain substring '%s'", err.Error(), "failed to parse contents of config file")
 	}
 
+}
+
+func (t *TestConfigTestSuite) TestConfigTelemetryClasses() {
+	cfgFile, err := t.createTemp("config.yaml")
+	t.Require().NoError(err, "creating config file")
+	cfgPath := cfgFile.Name()
+
+	err = cfgFile.Close()
+	t.Require().NoError(err, "closing created config file")
+
+	cfg, err := NewConfig(cfgPath)
+	t.Require().NoError(err, "loading config")
+
+	// ensure telemetry collection is enabled
+	cfg.Enabled = true
+
+	// enable opt-in and opt out telemetry
+	cfg.ClassOptions.OptIn = true
+	cfg.ClassOptions.OptOut = true
+
+	// all should be enabled
+	t.True(cfg.TelemetryClassEnabled(types.MANDATORY_TELEMETRY), "mandatory always enabled")
+	t.True(cfg.TelemetryClassEnabled(types.OPT_IN_TELEMETRY), "opt-in should be enabled")
+	t.True(cfg.TelemetryClassEnabled(types.OPT_OUT_TELEMETRY), "opt-out should be enabled")
+
+	// disable opt-in and opt out telemetry
+	cfg.ClassOptions.OptIn = false
+	cfg.ClassOptions.OptOut = false
+
+	// only mandatory should be enabled
+	t.True(cfg.TelemetryClassEnabled(types.MANDATORY_TELEMETRY), "mandatory always enabled")
+	t.False(cfg.TelemetryClassEnabled(types.OPT_IN_TELEMETRY), "opt-in should be disabled")
+	t.False(cfg.TelemetryClassEnabled(types.OPT_OUT_TELEMETRY), "opt-out should be disabled")
+
+	// unrecognised class should be disabled
+	t.False(cfg.TelemetryClassEnabled(999999999), "unrecognised class should be disabled")
+
+	// disable telemetry collection
+	cfg.Enabled = false
+
+	// all should be disabled
+	t.False(cfg.TelemetryClassEnabled(types.MANDATORY_TELEMETRY), "telemetry gathering disabled")
+	t.False(cfg.TelemetryClassEnabled(types.OPT_IN_TELEMETRY), "telemetry gathering disabled")
+	t.False(cfg.TelemetryClassEnabled(types.OPT_OUT_TELEMETRY), "telemetry gathering disabled")
+}
+
+func (t *TestConfigTestSuite) TestConfigTelemetryTypes() {
+	cfgFile, err := t.createTemp("config.yaml")
+	t.Require().NoError(err, "creating config file")
+	cfgPath := cfgFile.Name()
+
+	err = cfgFile.Close()
+	t.Require().NoError(err, "closing created config file")
+
+	cfg, err := NewConfig(cfgPath)
+	t.Require().NoError(err, "loading config")
+
+	// ensure telemetry collection is enabled
+	cfg.Enabled = true
+
+	// confirm any telemetry permitted when allow and deny lists are empty
+	t.True(cfg.TelemetryTypeEnabled("TYPE1"), "allowed if lists are empty")
+	t.True(cfg.TelemetryTypeEnabled("TYPE2"), "allowed if lists are empty")
+
+	// add test type to the allow list
+	cfg.ClassOptions.Allow = append(cfg.ClassOptions.Allow, "TYPE1")
+
+	// only allowed telemetry types should be permitted
+	t.True(cfg.TelemetryTypeEnabled("TYPE1"), "allowed telemetry should be enabled")
+	t.False(cfg.TelemetryTypeEnabled("TYPE2"), "only allowed telemetry should be enabled")
+
+	// add test type to the deny list
+	cfg.ClassOptions.Deny = append(cfg.ClassOptions.Deny, "TYPE1")
+
+	// deny list overrides allow list
+	t.False(cfg.TelemetryTypeEnabled("TYPE1"), "deny list overrides allow list")
+	t.False(cfg.TelemetryTypeEnabled("TYPE2"), "if not denied still needs to be allowed")
+
+	// tests should be enabled if in allow list but not in deny list
+	cfg.ClassOptions.Allow = append(cfg.ClassOptions.Allow, "TYPE2")
+	t.True(cfg.TelemetryTypeEnabled("TYPE2"), "allowed but not denied telemetry should be enabled")
+
+	// clear allow list so only deny list active
+	cfg.ClassOptions.Allow = []types.TelemetryType{}
+
+	// tests should be enabled so long as not in deny list if allow list is empty
+	t.False(cfg.TelemetryTypeEnabled("TYPE1"), "denied if in deny list")
+	t.True(cfg.TelemetryTypeEnabled("TYPE2"), "allowed if not in deny list")
+
+	// confirm tests still enabled if both lists are empty
+	cfg.ClassOptions.Deny = []types.TelemetryType{}
+	t.True(cfg.TelemetryTypeEnabled("TYPE1"), "allowed if lists are empty")
+	t.True(cfg.TelemetryTypeEnabled("TYPE2"), "allowed if lists are empty")
+
+	// disable telemetry collection
+	cfg.Enabled = false
+
+	// tests should be disabled if collection disabled
+	t.False(cfg.TelemetryTypeEnabled("TYPE1"), "denied if collection disabled")
+	t.False(cfg.TelemetryTypeEnabled("TYPE2"), "denied if collection disabled")
 }
 
 func TestTelemetryClientConfigTestSuite(t *testing.T) {

--- a/pkg/lib/processor_test.go
+++ b/pkg/lib/processor_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/SUSE/telemetry/pkg/config"
 	"github.com/SUSE/telemetry/pkg/types"
-	"github.com/SUSE/telemetry/pkg/utils"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
@@ -341,7 +341,7 @@ func addDataItems(totalItems int, processor TelemetryProcessor) error {
 		`
 	numItems := 1
 	for numItems <= totalItems {
-		formattedJSON := types.NewTelemetryBlob([]byte(fmt.Sprintf(payload, utils.GenerateRandomString(3))))
+		formattedJSON := types.NewTelemetryBlob([]byte(fmt.Sprintf(payload, uuid.New().String())))
 		err := processor.AddData(telemetryType, formattedJSON, tags)
 		if err != nil {
 			slog.Error(

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -4,33 +4,9 @@ import (
 	"bytes"
 	"compress/gzip"
 	"database/sql"
-	"encoding/json"
 	"fmt"
 	"io"
-
-	"github.com/xyproto/randomstring"
 )
-
-func GenerateRandomString(length int) string {
-	return randomstring.HumanFriendlyString(length)
-}
-
-func SerializeMap(m map[string]interface{}) (string, error) {
-	jsonData, err := json.Marshal(m)
-	if err != nil {
-		return "", err
-	}
-	return string(jsonData), nil
-}
-
-func DeserializeMap(jsonStr string) (map[string]interface{}, error) {
-	var m map[string]interface{}
-	err := json.Unmarshal([]byte(jsonStr), &m)
-	if err != nil {
-		return nil, err
-	}
-	return m, nil
-}
 
 func CompressGZIP(data []byte) (compressedData []byte, err error) {
 	var tmpBuffer bytes.Buffer

--- a/testdata/config/.gitignore
+++ b/testdata/config/.gitignore
@@ -1,0 +1,2 @@
+registration*
+credentials*

--- a/testdata/config/localClient.yaml
+++ b/testdata/config/localClient.yaml
@@ -1,16 +1,17 @@
 telemetry_base_url: http://localhost:9999/telemetry
 enabled: true
-customer_id: 1234567890
+client_id: d19ecc03-787c-469b-8bf5-71df704f3b16
+customer_id: TEST_CUSTOMER
 tags: []
 datastores:
   driver: sqlite3
   params: /tmp/telemetry/client/telemetry.db
-logging:
-  level: info
-  location: stderr
-  style: text
 class_options:
   opt_out: true
   opt_in: false
   allow: []
   deny: []
+logging:
+  level: info
+  location: stderr
+  style: text


### PR DESCRIPTION
Added support to the main telemetry module for managing the telemetry client id and customer id values in the telemetry config file.

Similarly added support for specifying an alternate location for the config file to be loaded by the telemetry module.

Reworked registration and credentials location determination to be relative to the location of the config file being used.

Renamed the credentials file from auth.json to credentials.

Enhancements to the integration of the ManagedFile type with config management, including support for saving and loading config files.

Updated the registration management to leverage the ManagedFile.

Minor tweaks to ManagedFile implementation to support integration with config and registration management workflows.

Re-work how config default values are maintained and used.

Add test coverage for the telemetry class options config settings and fix some minor issues the were uncovered. Additionally improve overall testing coverage in a number of areas.

Re-order make sub-directories list to do the top-level directory last.

Add a test-coverage target to the Makefile targets that reports the summary test coverage status. Also moved default goal and the go coverage profile definition to the top-level Makefile context.

Added git ignorance for registration and credentials files adjacent to the testing config files under testdata/config.

Updated testdata/config/localClient.yaml:
* Added a client_id
* Updated the customer_id to be a string
* Re-ordered content to match order generated by code.

Fix some remaining references to the X-Telemetry-Client-Id header in the docs.

Drop usage of randomstring module.