### PR TITLE
Allow duplicate client ids

### DIFF
--- a/doc/telemetryclientregistration.md
+++ b/doc/telemetryclientregistration.md
@@ -10,36 +10,37 @@ a telemetry service client.
 This client registration structure has the following format:
 ```
 {
-  "clientId": "<client_generated_UUID>",
+  "clientId": "<SCC_assigned_or_client_generated_UUID>",
   "systemUUID": "<optional_system_UUID>",
-  "timestamp": "<time_when_client_id_was_generated>"
+  "timestamp": "<time_when_registration_id_was_generated>"
 }
 ```
 
 ## Client Registration Collisions
 A client system may be required to generate a new client registration
 if the upstream server detects that the registration is a duplicate
-of an existing registration, or that the registration's clientId is
-a duplicate of existing client's clientId.
+of an existing registration.
 
 The client registration's clientId value is used to identify the
 client generating a [telemetry bundle](api/structs/telemetrybundle.md)
 and submitting a [telemetry report](api/structs/telemetryreport.md).
 
-## Uniquely Identifying a client
+## Uniquely identifying telemetry submitted by a client
 On its own the clientId may not always uniquely identify a client
-within the overall pool of telemetry service submissions, because two
-client systems could independently generate the same UUID value to use
-as a clientId, but a telemetry client's clientId will always be unique
-with respect to other clients of the same upstream telemetry service.
+within the overall pool of telemetry service submissions because,
+while extremely unlikely, there is a chance that two independent
+client systems could generate the same UUID value for use as a
+telemetry client id.
 
-This property, that clientIds will always be unique with respect to
-other clients of the same upstream telemetry service, can be leveraged
-by [telemetry relays](telemetryrelay.md) to assist in uniquely
-identifying telemetry clients.  When telemetry is relayed, the relay
-will add a RELAYED_VIA tag to the telemetry submission which identifies
-both the relay and the client that submitted the telemetry to the
-relay. The aggregate of the RELAYED_VIA tag values associated with a
-telemetry data item can thus be used to uniquely identify the path
-from the originating client to the main telemetry service gateway,
-and thus uniquely identify a specific client's telemetry submissions.
+Note that in the case of client systems registered with the SCC,
+the risk of duplicates will be further reduced because telemetry
+client ids will be assigned by the SCC and will be unique with
+respect to other registered SCC clients at that time.
+
+A [telemetry relay](telemetryrelay.md) will include a RELAYED_VIA
+tag specifying the client id that submitted the telemetry report,
+and the telemetry relay server's telemetry client id. Combining
+any RELAYED_VIA tag values associated with a telemetry submission
+along with the telemetry client id of the client that generated the
+telemetry should further allow for uniquely identifying telemetry
+submitted by a specific client.


### PR DESCRIPTION
The docs associated with telemetry client registration should reflect that the telemetry server will allow for client ids to be duplicated; the registrations must still be unique, but a server will not reject a client registration if the embedded client id value is a duplicate.