### PR TITLE
Authenication failures may require re-registration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,5 +19,16 @@ jobs:
         with:
           path: telemetry
 
-      - name: Run tests in verbose mode
-        run: cd telemetry && make test-verbose
+      - name: Run tests in verbose mode as non-root testuser
+        run: |
+          set -eu
+
+          echo Creating testuser account
+          useradd -m -U -s /bin/bash testuser
+
+          echo Changing ownership of directories accessed by the test
+          chown -R testuser:testuser telemetry /go
+
+          echo Running tests as testuser
+          cd telemetry
+          runuser -u testuser make test-verbose

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,12 +23,13 @@ jobs:
         run: |
           set -eu
 
-          echo Creating testuser account
-          useradd -m -U -s /bin/bash testuser
+          testuser=${TESTUSER:-susetelm}
+          echo Creating ${testuser} account
+          useradd -m -U -s /bin/bash ${testuser}
 
           echo Changing ownership of directories accessed by the test
-          chown -R testuser:testuser telemetry /go
+          chown -R ${testuser}:${testuser} telemetry /go
 
-          echo Running tests as testuser
+          echo Running tests as ${testuser}
           cd telemetry
-          runuser -u testuser make test-verbose
+          runuser -u ${testuser} make test-verbose

--- a/pkg/client/credentials_management.go
+++ b/pkg/client/credentials_management.go
@@ -1,0 +1,287 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+
+	"github.com/SUSE/telemetry/pkg/config"
+	"github.com/SUSE/telemetry/pkg/restapi"
+	"github.com/SUSE/telemetry/pkg/utils"
+)
+
+const (
+	CREDENTIALS_NAME = `credentials`
+	CREDENTIALS_PERM = 0600
+)
+
+type TelemetryCreds struct {
+	restapi.ClientRegistrationResponse
+}
+
+func (ta *TelemetryCreds) String() string {
+	bytes, _ := json.Marshal(ta)
+	return string(bytes)
+}
+
+type TelemetryClientCredentials struct {
+	TelemetryCreds
+	config    *config.Config
+	credsFile utils.FileManager
+	valid     bool
+	no_retry  bool
+}
+
+func NewTelemetryClientCredentials(cfg *config.Config) (*TelemetryClientCredentials, error) {
+	credsPath := filepath.Join(cfg.ConfigDir(), CREDENTIALS_NAME)
+	c := &TelemetryClientCredentials{
+		config:   cfg,
+		valid:    false,
+		no_retry: false,
+	}
+
+	// create a managed file to manage the credentials file based upon
+	// the location, ownership and permissions of the config file with
+	// backups disabled.
+	fm := utils.NewManagedFile()
+	err := fm.Init(
+		credsPath,
+		c.config.ConfigUser(),
+		c.config.ConfigGroup(),
+		CREDENTIALS_PERM,
+	)
+	fm.DisableBackups()
+
+	if err != nil {
+		slog.Debug(
+			"failed to setup credentials file manager",
+			slog.String("path", credsPath),
+			slog.String("err", err.Error()),
+		)
+		return nil, fmt.Errorf("failed to setup credentials file manager: %w", err)
+	}
+
+	c.credsFile = fm
+
+	return c, nil
+}
+
+func (c *TelemetryClientCredentials) UpdateCreds(creds *restapi.ClientAuthenticationResponse) (err error) {
+	// stored the provided credentials
+	c.ClientRegistrationResponse = *creds
+
+	// mark credentials as valid
+	c.valid = true
+
+	// attempt to save the updated credentials
+	err = c.Save()
+	if err != nil {
+		// we failed to save the credentials so mark them as invalid
+		c.valid = false
+
+		return
+	}
+
+	return
+}
+
+func (c *TelemetryClientCredentials) Exists() bool {
+	exists, _ := c.credsFile.Exists()
+	return exists
+}
+
+func (c *TelemetryClientCredentials) RetriesEnabled() bool {
+	return !c.no_retry
+}
+
+func (c *TelemetryClientCredentials) DisableRetries() {
+	c.no_retry = true
+}
+
+func (c *TelemetryClientCredentials) Valid() bool {
+	return c.valid
+}
+
+func (c *TelemetryClientCredentials) Path() string {
+	return c.credsFile.Path()
+}
+
+func (c *TelemetryClientCredentials) Accessible() bool {
+	exists, _ := c.credsFile.Accessible()
+	return exists
+}
+
+func (c *TelemetryClientCredentials) Credentials() TelemetryCreds {
+	return c.TelemetryCreds
+}
+
+func (c *TelemetryClientCredentials) String() string {
+	return fmt.Sprintf(
+		"<p:%q, v:%v, c:%q>",
+		c.Path(),
+		c.valid,
+		c.TelemetryCreds.String(),
+	)
+}
+
+func (c *TelemetryClientCredentials) Save() (err error) {
+	// saving an invalid credentials is not supported
+	if !c.valid {
+		return fmt.Errorf("client credentials not valid; cannot save")
+	}
+
+	err = c.credsFile.Create()
+	if err != nil {
+		slog.Debug(
+			"failed to create/open credentials",
+			slog.String("path", c.Path()),
+			slog.String("err", err.Error()),
+		)
+	}
+	defer c.credsFile.Close()
+
+	// marshal the credentials public fields as JSON
+	bytes, err := json.Marshal(c)
+	if err != nil {
+		slog.Error(
+			"failed to json.Marshal() client credentials",
+			slog.String("creds", c.String()),
+			slog.String("err", err.Error()),
+		)
+		return
+	}
+
+	// save the JSON encoded credentials fields
+	err = c.credsFile.Update(bytes)
+	if err != nil {
+		slog.Error(
+			"failed to save client credentials file",
+			slog.String("creds", c.String()),
+			slog.String("err", err.Error()),
+		)
+		return
+	}
+
+	slog.Debug(
+		"client credentials saved",
+		slog.String("reg", c.String()),
+	)
+	return
+}
+
+func (c *TelemetryClientCredentials) Load() (err error) {
+	// check that the specified path exists, failing appropriately
+	exists, err := c.credsFile.Exists()
+	if err != nil {
+		slog.Debug(
+			"unable to check for client credentials file",
+			slog.String("path", c.Path()),
+			slog.String("err", err.Error()),
+		)
+	}
+	if !exists {
+		slog.Error(
+			"client credentials file not found",
+			slog.String("path", c.Path()),
+		)
+		return
+	}
+
+	// open the credentials file
+	err = c.credsFile.Open(
+		false, // no need to create, should already exist
+	)
+	if err != nil {
+		slog.Error(
+			"failed to open client credentials",
+			slog.String("path", c.Path()),
+		)
+		return
+	}
+	defer c.credsFile.Close()
+
+	// retrieve the contents of the specified client credentials file
+	bytes, err := c.credsFile.Read()
+	if err != nil {
+		slog.Error(
+			"failed to read client credentials file",
+			slog.String("path", c.Path()),
+			slog.String("err", err.Error()),
+		)
+		return
+	}
+
+	// unmarshal the contents of the client credentials file into the
+	// client credentials structure
+	err = json.Unmarshal(bytes, c)
+	if err != nil {
+		slog.Error(
+			"failed to json.Unmarshal() client credentials file contents",
+			slog.String("path", c.Path()),
+			slog.String("contents", string(bytes)),
+			slog.String("err", err.Error()),
+		)
+		return
+	}
+
+	// validate the loaded contents
+	err = c.Valdiate()
+	if err != nil {
+		slog.Error(
+			"failed to validate client credentials file contents",
+			slog.String("path", c.Path()),
+			slog.String("contents", string(bytes)),
+			slog.String("err", err.Error()),
+		)
+		return
+	}
+
+	// mark credentials as valid
+	c.valid = true
+
+	slog.Debug(
+		"client credentials loaded",
+		slog.String("path", c.Path()),
+		slog.String("reg", c.String()),
+	)
+
+	return
+}
+
+func (c *TelemetryClientCredentials) Remove() (err error) {
+	// mark in-memory version as invalid
+	c.valid = false
+
+	// nothing to do if file doesn't exist
+	exists, _ := c.credsFile.Exists()
+	if !exists {
+		return
+	}
+
+	// delete the credentials file
+	err = c.credsFile.Delete()
+	if err != nil {
+		slog.Error(
+			"failed to delete client credentials",
+			slog.String("path", c.Path()),
+			slog.String("err", err.Error()),
+		)
+		return fmt.Errorf("failed to os.Remove(%q): %w", c.Path(), err)
+	}
+
+	return
+}
+
+func (c *TelemetryClientCredentials) Valdiate() (err error) {
+
+	err = c.TelemetryCreds.Validate()
+	if err != nil {
+		slog.Debug(
+			"client credentials validation failed",
+			slog.String("err", err.Error()),
+		)
+	}
+
+	return
+}

--- a/pkg/client/credentials_management.go
+++ b/pkg/client/credentials_management.go
@@ -226,7 +226,7 @@ func (c *TelemetryClientCredentials) Load() (err error) {
 	}
 
 	// validate the loaded contents
-	err = c.Valdiate()
+	err = c.Validate()
 	if err != nil {
 		slog.Error(
 			"failed to validate client credentials file contents",
@@ -273,7 +273,7 @@ func (c *TelemetryClientCredentials) Remove() (err error) {
 	return
 }
 
-func (c *TelemetryClientCredentials) Valdiate() (err error) {
+func (c *TelemetryClientCredentials) Validate() (err error) {
 
 	err = c.TelemetryCreds.Validate()
 	if err != nil {

--- a/pkg/client/registration_management.go
+++ b/pkg/client/registration_management.go
@@ -234,7 +234,7 @@ func (r *TelemetryClientRegistration) Load() (err error) {
 	}
 
 	// validate the loaded contents
-	err = r.Valdiate()
+	err = r.Validate()
 	if err != nil {
 		slog.Error(
 			"failed to validate client registration file contents",
@@ -281,7 +281,7 @@ func (r *TelemetryClientRegistration) Remove() (err error) {
 	return
 }
 
-func (c *TelemetryClientRegistration) Valdiate() (err error) {
+func (c *TelemetryClientRegistration) Validate() (err error) {
 
 	err = c.ClientRegistration.Validate()
 	if err != nil {

--- a/pkg/client/report.go
+++ b/pkg/client/report.go
@@ -33,8 +33,8 @@ func (tc *TelemetryClient) submitReportInternal(report *telemetrylib.TelemetryRe
 	}
 
 	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("Authorization", "Bearer "+tc.auth.Token.String())
-	req.Header.Add("X-Telemetry-Registration-Id", fmt.Sprintf("%d", tc.auth.RegistrationId))
+	req.Header.Add("Authorization", "Bearer "+tc.creds.AuthToken)
+	req.Header.Add("X-Telemetry-Registration-Id", fmt.Sprintf("%d", tc.creds.RegistrationId))
 
 	httpClient := http.DefaultClient
 	resp, err := httpClient.Do(req)
@@ -122,7 +122,7 @@ func (tc *TelemetryClient) submitReportRetry(
 
 			// force a (re-)registration by deleting any existing
 			// client creds bundle
-			err = tc.deleteTelemetryAuth()
+			err = tc.creds.Remove()
 			if err != nil {
 				slog.Warn(
 					"Failed to delete existing telemetry auth bundle",

--- a/pkg/lib/bundles.go
+++ b/pkg/lib/bundles.go
@@ -90,7 +90,7 @@ type TelemetryBundleHeader struct {
 	// NOTE: omitempty option used in json tags to support generating test scenarios
 	BundleId          string   `json:"bundleId,omitempty" validate:"required,uuid4"`
 	BundleTimeStamp   string   `json:"bundleTimeStamp" validate:"required"`
-	BundleClientId    string   `json:"bundleClientId,omitempty" validate:"required,uuid4"`
+	BundleClientId    string   `json:"bundleClientId" validate:"required,uuid4"`
 	BundleCustomerId  string   `json:"bundleCustomerId" validate:"omitempty"`
 	BundleAnnotations []string `json:"bundleAnnotations,omitempty"`
 }

--- a/pkg/lib/items.go
+++ b/pkg/lib/items.go
@@ -16,7 +16,7 @@ type TelemetryDataItem struct {
 	// NOTE: omitempty option used in json tags to support generating test scenarios
 	Header        TelemetryDataItemHeader `json:"header"  validate:"required"`
 	TelemetryData json.RawMessage         `json:"telemetryData"  validate:"required,dive"`
-	Footer        TelemetryDataItemFooter `json:"footer,omitempty" validate:"required"`
+	Footer        TelemetryDataItemFooter `json:"footer,omitempty" validate:"omitempty"`
 }
 
 func (tdi *TelemetryDataItem) UpdateChecksum() (err error) {

--- a/pkg/lib/items.go
+++ b/pkg/lib/items.go
@@ -15,7 +15,7 @@ import (
 type TelemetryDataItem struct {
 	// NOTE: omitempty option used in json tags to support generating test scenarios
 	Header        TelemetryDataItemHeader `json:"header"  validate:"required"`
-	TelemetryData json.RawMessage         `json:"telemetryData,omitempty"  validate:"required,dive"`
+	TelemetryData json.RawMessage         `json:"telemetryData"  validate:"required,dive"`
 	Footer        TelemetryDataItemFooter `json:"footer,omitempty" validate:"required"`
 }
 

--- a/pkg/lib/reports.go
+++ b/pkg/lib/reports.go
@@ -103,7 +103,7 @@ type TelemetryReportHeader struct {
 	// NOTE: omitempty option used in json tags to support generating test scenarios
 	ReportId          string   `json:"reportId,omitempty" validate:"required,uuid4"`
 	ReportTimeStamp   string   `json:"reportTimeStamp" validate:"required"`
-	ReportClientId    string   `json:"reportClientId,omitempty" validate:"required,uuid4"`
+	ReportClientId    string   `json:"reportClientId" validate:"required,uuid4"`
 	ReportAnnotations []string `json:"reportAnnotations,omitempty"`
 }
 

--- a/pkg/restapi/restapi.go
+++ b/pkg/restapi/restapi.go
@@ -6,6 +6,7 @@ import (
 
 	telemetrylib "github.com/SUSE/telemetry/pkg/lib"
 	"github.com/SUSE/telemetry/pkg/types"
+	"github.com/go-playground/validator/v10"
 )
 
 //
@@ -25,15 +26,26 @@ func (c *ClientRegistrationRequest) String() string {
 
 // ClientRegistrationResponse is the response payload body from the server
 type ClientRegistrationResponse struct {
-	RegistrationId   int64  `json:"registrationId"`
-	AuthToken        string `json:"authToken"`
-	RegistrationDate string `json:"registrationDate"`
+	RegistrationId   int64  `json:"registrationId" validate:"required,min=1"`
+	AuthToken        string `json:"authToken" validate:"required,jwt"`
+	RegistrationDate string `json:"registrationDate" validate:"required,datetime=2006-01-02T15:04:05.999999999Z07:00"`
 }
 
 func (c *ClientRegistrationResponse) String() string {
 	bytes, _ := json.Marshal(c)
 
 	return string(bytes)
+}
+
+func (c *ClientRegistrationResponse) Validate() (err error) {
+	validate := validator.New()
+
+	err = validate.Struct(c)
+	if err != nil {
+		err = fmt.Errorf("client credentials validation check failed: %w", err)
+	}
+
+	return
 }
 
 // Client Authenticate handling via /temelemtry/authenticate

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -9,6 +9,8 @@ import (
 	"hash"
 	"strings"
 	"time"
+
+	"github.com/go-playground/validator/v10"
 )
 
 // Tag is a string of the form "name" or "name=value"
@@ -146,14 +148,25 @@ func (c *ClientRegistrationHash) Match(m *ClientRegistrationHash) bool {
 
 // ClientRegistration
 type ClientRegistration struct {
-	ClientId   string `json:"clientId"`
-	SystemUUID string `json:"systemUUID"`
-	Timestamp  string `json:"timestamp"`
+	ClientId   string `json:"clientId" validate:"required,uuid4"`
+	SystemUUID string `json:"systemUUID" validate:"omitempty,gt=0,uuid"`
+	Timestamp  string `json:"timestamp" validate:"required,datetime=2006-01-02T15:04:05.999999999Z07:00"`
 }
 
 func (c *ClientRegistration) String() string {
 	bytes, _ := json.Marshal(c)
 	return string(bytes)
+}
+
+func (c *ClientRegistration) Validate() (err error) {
+	validate := validator.New()
+
+	err = validate.Struct(c)
+	if err != nil {
+		err = fmt.Errorf("client registration validation check failed: %w", err)
+	}
+
+	return
 }
 
 const DEF_INSTID_HASH_METHOD = "sha256"

--- a/pkg/utils/managed_file.go
+++ b/pkg/utils/managed_file.go
@@ -198,6 +198,7 @@ type FileManager interface {
 	Path() string
 	SetPath(filePath string) error
 	Exists() (bool, error)
+	Accessible() (bool, error)
 
 	// file ownership and permissions
 	User() string
@@ -393,6 +394,19 @@ func (fm *ManagedFile) SetPath(path string) (err error) {
 	}
 
 	fm.path = absPath
+	return
+}
+
+func (fm *ManagedFile) Accessible() (accessible bool, err error) {
+	if err = fm.checkPath(); err != nil {
+		return
+	}
+
+	fm.dbg("checking if managed file is accessible")
+	if _, err := os.Open(fm.Path()); err == nil {
+		accessible = true
+	}
+
 	return
 }
 

--- a/pkg/utils/managed_file_test.go
+++ b/pkg/utils/managed_file_test.go
@@ -52,8 +52,6 @@ func (t *FileManagerTestSuite) SkipIfRoot() {
 }
 
 func (t *FileManagerTestSuite) Test_Paths() {
-	var accessible bool
-
 	// use a common test file path
 	filename := filepath.Join(t.tmpDir, "test_file")
 
@@ -87,6 +85,31 @@ func (t *FileManagerTestSuite) Test_Paths() {
 
 	err = fm.UseExistingFile(filename)
 	t.NoError(err, "fm.UseExistingFile() should work")
+}
+
+func (t *FileManagerTestSuite) Test_Accessible() {
+	t.SkipIfRoot()
+
+	var accessible bool
+	var err error
+
+	// use a common test file path
+	filename := filepath.Join(t.tmpDir, "test_file")
+
+	fm := NewManagedFile()
+	defer fm.Close()
+
+	// create a managed file
+	err = fm.Init(
+		filename,
+		"",
+		"",
+		0600,
+	)
+	t.NoError(err, "fm.Init() with absolute path")
+
+	err = fm.Create()
+	t.NoError(err, "fm.Create() should work")
 
 	accessible, err = fm.Accessible()
 	t.NoError(err, "accessibility check should have worked")

--- a/pkg/utils/managed_file_test.go
+++ b/pkg/utils/managed_file_test.go
@@ -52,10 +52,12 @@ func (t *FileManagerTestSuite) SkipIfRoot() {
 }
 
 func (t *FileManagerTestSuite) Test_Paths() {
+	var accessible bool
+
 	// use a common test file path
 	filename := filepath.Join(t.tmpDir, "test_file")
 
-	t.False(CheckPathExists(filename), "test file shouldn't exist yet")
+	t.False(CheckPathExists(filename), "test_file shouldn't exist yet")
 
 	fm := NewManagedFile()
 	defer fm.Close()
@@ -81,10 +83,21 @@ func (t *FileManagerTestSuite) Test_Paths() {
 	err = fm.Create()
 	t.NoError(err, "fm.Create() should work")
 
-	t.True(CheckPathExists(filename), "test file should exist now")
+	t.True(CheckPathExists(filename), "test_file should exist now")
 
 	err = fm.UseExistingFile(filename)
 	t.NoError(err, "fm.UseExistingFile() should work")
+
+	accessible, err = fm.Accessible()
+	t.NoError(err, "accessibility check should have worked")
+	t.True(accessible, "test_file should be accessible")
+
+	err = os.Chmod(fm.Path(), 0000)
+	t.NoError(err, "chmod'ing test_file file to be inaccessible")
+
+	accessible, err = fm.Accessible()
+	t.NoError(err, "accessibility check should have worked")
+	t.False(accessible, "test_file shouldn't be accessible")
 }
 
 func (t *FileManagerTestSuite) Test_InitUserGroup() {

--- a/telemetry.go
+++ b/telemetry.go
@@ -300,9 +300,12 @@ func Status() (status ClientStatus) {
 	// update status to indicate client has registration
 	status = CLIENT_REGISTRATION_ACCESSIBLE
 
-	// check that we have obtained a telemetry auth token
-	if !tc.AuthAccessible() {
-		slog.Warn("Telemetry client has not been registered", slog.String("path", tc.AuthPath()))
+	// check that we have obtained telemetry client credentials
+	if !tc.CredentialsAccessible() {
+		slog.Warn(
+			"Telemetry client has not been registered",
+			slog.String("path", tc.CredentialsPath()),
+		)
 		return
 	}
 


### PR DESCRIPTION
In some cases an authentication failure may require a client to re-register rather than just re-authenticate.

Migrate credentials management to use the ManagedFile mechanisms. Also rename TelemetryAuth to TelemetryCreds, and similarly for associated field in the TelemetryClient.

Use the ClientRegistrationResponse structure as the credientials type, rather than replicating as an almost equivalent type.

Update registration and credentials backing types with validate tags and use the validator to ensure that the contents are valid after loading the content from disk.

Re-work the TelemetryClient initialisation to load the registration and credentials files when they already exist.

Add Accessible() method to ManagedFile that can be used to confirm that a file not only exists but can be read. Added a test to verify this new method.

Also update DataItem, Bundle and Report structure json tags to remove omitempty directives that conflict with validate required directives.