### PR TITLE
Relax UUID validation checks

### DIFF
--- a/pkg/lib/bundles.go
+++ b/pkg/lib/bundles.go
@@ -88,9 +88,9 @@ func NewTelemetryBundle(clientId string, customerId string, tags types.Tags) (*T
 
 type TelemetryBundleHeader struct {
 	// NOTE: omitempty option used in json tags to support generating test scenarios
-	BundleId          string   `json:"bundleId,omitempty" validate:"required,uuid4"`
+	BundleId          string   `json:"bundleId,omitempty" validate:"required,uuid|uuid_rfc4122"`
 	BundleTimeStamp   string   `json:"bundleTimeStamp" validate:"required"`
-	BundleClientId    string   `json:"bundleClientId" validate:"required,uuid4"`
+	BundleClientId    string   `json:"bundleClientId" validate:"required,uuid|uuid_rfc4122"`
 	BundleCustomerId  string   `json:"bundleCustomerId" validate:"omitempty"`
 	BundleAnnotations []string `json:"bundleAnnotations,omitempty"`
 }

--- a/pkg/lib/items.go
+++ b/pkg/lib/items.go
@@ -71,7 +71,7 @@ func NewTelemetryDataItem(telemetry types.TelemetryType, tags types.Tags, conten
 }
 
 type TelemetryDataItemHeader struct {
-	TelemetryId          string   `json:"telemetryId"  validate:"required,uuid4"`
+	TelemetryId          string   `json:"telemetryId"  validate:"required,uuid|uuid_rfc4122"`
 	TelemetryTimeStamp   string   `json:"telemetryTimeStamp"  validate:"required"`
 	TelemetryType        string   `json:"telemetryType"  validate:"required,min=5"`
 	TelemetryAnnotations []string `json:"telemetryAnnotations,omitempty"`

--- a/pkg/lib/reports.go
+++ b/pkg/lib/reports.go
@@ -101,9 +101,9 @@ func NewTelemetryReport(clientId string, tags types.Tags) (*TelemetryReport, err
 
 type TelemetryReportHeader struct {
 	// NOTE: omitempty option used in json tags to support generating test scenarios
-	ReportId          string   `json:"reportId,omitempty" validate:"required,uuid4"`
+	ReportId          string   `json:"reportId,omitempty" validate:"required,uuid|uuid_rfc4122"`
 	ReportTimeStamp   string   `json:"reportTimeStamp" validate:"required"`
-	ReportClientId    string   `json:"reportClientId" validate:"required,uuid4"`
+	ReportClientId    string   `json:"reportClientId" validate:"required,uuid|uuid_rfc4122"`
 	ReportAnnotations []string `json:"reportAnnotations,omitempty"`
 }
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -148,8 +148,8 @@ func (c *ClientRegistrationHash) Match(m *ClientRegistrationHash) bool {
 
 // ClientRegistration
 type ClientRegistration struct {
-	ClientId   string `json:"clientId" validate:"required,uuid4"`
-	SystemUUID string `json:"systemUUID" validate:"omitempty,gt=0,uuid"`
+	ClientId   string `json:"clientId" validate:"required,uuid|uuid_rfc4122"`
+	SystemUUID string `json:"systemUUID" validate:"omitempty,gt=0,uuid|uuid_rfc4122"`
 	Timestamp  string `json:"timestamp" validate:"required,datetime=2006-01-02T15:04:05.999999999Z07:00"`
 }
 


### PR DESCRIPTION
Previously we permitted only lowercase UUIDv4 format UUIDs. Relax this to allow any RFC4122 compliant UUID, in uppercase or lowercase.