### PR TITLE
Update client registration hash generation

### DIFF
--- a/doc/api/requests/authenticate.md
+++ b/doc/api/requests/authenticate.md
@@ -10,6 +10,25 @@ Type: **POST**
 
 Request body type `ClientAuthenticationRequest` defined in [restapi module](../../../pkg/restapi)
 
+### ClientRegistration Hashing
+The `regHash` field in the request body consists of 2 fields, `method`
+and `value`, and represents the hash of the client's `ClientRegistration`
+using the given hashing method.
+
+Originally the input to the hashing method was the JSON encoding of the
+client's `ClientRegistration`, but due to inconsistencies between the
+JSON encoding across different platforms, going forward the input to the
+hashing method with be the 3 fields of `ClientRegistration` joined with
+`|` between each field, e.g. `<clientId>|<systemUUID>|<timestamp>`.
+
+The supported hashing methods that can be specified by the `method` field are:
+* `sha256`
+* `sha512`
+
+### Backwards compatibility
+For backwards compatibility support a `HashJSON()` method is available for
+the `ClientRegistration` to uses the JSON encoded value as the input.
+
 ## Responses
 
 | Code | Description | Example |

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -197,6 +197,15 @@ func (c *ClientRegistration) String() string {
 	return string(bytes)
 }
 
+func (c *ClientRegistration) Hashable() string {
+	return fmt.Sprintf(
+		"%s|%s|%s",
+		c.ClientId,
+		c.SystemUUID,
+		c.Timestamp,
+	)
+}
+
 func (c *ClientRegistration) Validate() (err error) {
 	validate := validator.New(validator.WithRequiredStructEnabled())
 
@@ -211,6 +220,14 @@ func (c *ClientRegistration) Validate() (err error) {
 const DEF_INSTID_HASH_METHOD = "sha256"
 
 func (c *ClientRegistration) Hash(inputMethod string) *ClientRegistrationHash {
+	return c.hashValue(inputMethod, c.Hashable())
+}
+
+func (c *ClientRegistration) HashJSON(inputMethod string) *ClientRegistrationHash {
+	return c.hashValue(inputMethod, c.String())
+}
+
+func (c *ClientRegistration) hashValue(inputMethod string, value string) *ClientRegistrationHash {
 	var methodHash hash.Hash
 
 	// this routine is expected to succeed so ensure a valid method is used
@@ -236,7 +253,7 @@ func (c *ClientRegistration) Hash(inputMethod string) *ClientRegistrationHash {
 	case "sha512":
 		methodHash = sha512.New()
 	}
-	methodHash.Write([]byte(c.String()))
+	methodHash.Write([]byte(value))
 
 	// construct the return value
 	return &ClientRegistrationHash{


### PR DESCRIPTION
Given that JSON encoding is not always consistent across different platforms, switch to using a custom encoding for ClientRegistration for the input value when generating the ClientRegistrationHash.

Provide a HashJSON() method that uses the JSON encoding as input to allow for backwards compatibility implementations.

Update documentation for the /authenticate request to document how the regHash field is encoded, and the switch to using a platform independent encoding scheme for the hashing input value.