### PR TITLE
Rename container image to telemetry-client-tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,9 +96,9 @@ RUN \
   cp ${telemetryBuildDir}/examples/app/app ${telemetryAppDir}/example
 
 #
-# Create the telemetry-tools image.
+# Create the telemetry-client-tools image.
 #
-FROM ${SLE_BCI_REG}/${SLE_BCI_IMAGE}:${SLE_BCI_VERSION} AS telemetry-tools
+FROM ${SLE_BCI_REG}/${SLE_BCI_IMAGE}:${SLE_BCI_VERSION} AS telemetry-client-tools
 
 # args used by this image
 ARG user

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -2,7 +2,7 @@
 CNTR_MGR ?= docker
 # docker container name
 CNTR_NAME = \
-  telemetry-tools
+  telemetry-client-tools
 
 # build vars/runtime env vars
 TELEMETRY_USER ?= susetelm


### PR DESCRIPTION
This avoids a naming conflict with SUSE/telemetry-server's image set which now includes a telemetry-tools image.